### PR TITLE
feat: design changes

### DIFF
--- a/boot_shutdown_interface/CMakeLists.txt
+++ b/boot_shutdown_interface/CMakeLists.txt
@@ -3,7 +3,7 @@ project(boot_shutdown_interface)
 
 find_package(ament_cmake_auto REQUIRED)
 find_package(Boost REQUIRED COMPONENTS
-  filesystem
+  serialization
 )
 
 ament_auto_find_build_dependencies()
@@ -11,6 +11,8 @@ ament_auto_find_build_dependencies()
 ament_auto_add_library(boot_shutdown_interface_node SHARED
   src/boot_shutdown_interface.cpp
 )
+
+target_link_libraries(boot_shutdown_interface_node ${Boost_LIBRARIES})
 
 rclcpp_components_register_node(boot_shutdown_interface_node
   PLUGIN "boot_shutdown_interface::BootShutdownInterface"

--- a/boot_shutdown_interface/config/boot_shutdown.param.yaml
+++ b/boot_shutdown_interface/config/boot_shutdown.param.yaml
@@ -9,3 +9,5 @@
       type: "autoware_auto_system_msgs/msg/AutowareState"
       transient_local: False
       best_effort: False
+
+    additional_prepare_shutdown_command: [""]

--- a/boot_shutdown_interface/include/boot_shutdown_interface/boot_shutdown_interface.hpp
+++ b/boot_shutdown_interface/include/boot_shutdown_interface/boot_shutdown_interface.hpp
@@ -15,6 +15,7 @@
 #ifndef BOOT_SHUTDOWN_INTERFACE__BOOT_SHUTDOWN_INTERFACE_HPP_
 #define BOOT_SHUTDOWN_INTERFACE__BOOT_SHUTDOWN_INTERFACE_HPP_
 
+#include <boot_shutdown_service/boot_shutdown_common.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <boot_shutdown_api_msgs/msg/ecu_state.hpp>
@@ -22,8 +23,7 @@
 #include <boot_shutdown_api_msgs/srv/prepare_shutdown.hpp>
 #include <std_msgs/msg/string.hpp>
 
-#include <boost/process.hpp>
-
+#include <memory>
 #include <string>
 
 namespace boot_shutdown_interface
@@ -35,35 +35,139 @@ using boot_shutdown_api_msgs::srv::PrepareShutdown;
 class BootShutdownInterface : public rclcpp::Node
 {
 public:
+  /**
+   * @brief Constructor
+   * @param [in] options Options associated with this node
+   */
   explicit BootShutdownInterface(const rclcpp::NodeOptions & options);
 
 private:
-  rclcpp::Publisher<EcuState>::SharedPtr pub_ecu_state_;
-  rclcpp::GenericSubscription::SharedPtr sub_topic_;
-  rclcpp::Service<PrepareShutdown>::SharedPtr srv_prepare_shutdown_;
-  rclcpp::Service<ExecuteShutdown>::SharedPtr srv_execute_shutdown_;
-  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::Publisher<EcuState>::SharedPtr pub_ecu_state_;  //!< @brief Publisher to notify ECU state
+  rclcpp::GenericSubscription::SharedPtr
+    sub_topic_;  //!< @brief Subscriber to check if ECU is running
+  rclcpp::Service<PrepareShutdown>::SharedPtr
+    srv_prepare_shutdown_;  //!< @brief Service to prepare shutdown
+  rclcpp::Service<ExecuteShutdown>::SharedPtr
+    srv_execute_shutdown_;              //!< @brief Service to execute shutdown
+  rclcpp::TimerBase::SharedPtr timer_;  //!< @brief Timer to notify ECU state
 
-  std::string ecu_name_;
-  unsigned int startup_timeout_;
-  unsigned int prepare_shutdown_time_;
-  unsigned int execute_shutdown_time_;
-  EcuState ecu_state_;
-  rclcpp::Time startup_time_;
-  rclcpp::Time prepare_shutdown_start_time_;
-  boost::process::child preparation_child_;
-  boost::process::child shutdown_child_;
+  unsigned int startup_timeout_;        //!< @brief Timeout time to wait for startup completion
+  unsigned int prepare_shutdown_time_;  //!< @brief Time taken for preparing shutdown
+  unsigned int execute_shutdown_time_;  //!< @brief Time taken for executing shutdown
+  std::vector<std::string> commands_;   //!< @brief List of additional prepare shutdown command
 
+  EcuState ecu_state_;                        //!< @brief Current ECU state
+  rclcpp::Time startup_time_;                 //!< @brief Startup time
+  rclcpp::Time prepare_shutdown_start_time_;  //!< @brief Start time from preparing shutdown
+  std::string socket_path_;                   //!< @brief Path of UNIX domain socket
+  int socket_;           //!< @brief Socket to communicate with boot-shutdown service
+  bool topic_received_;  //!< @brief A flag to receive topic or not
+
+  /**
+   * @brief Check topic_config parameter in yaml
+   */
   void createTopicChecker();
+
+  /**
+   * @brief Callback for the service request to prepare for shutdown
+   * @param [in] request Service request
+   * @param [in] response Service response
+   */
   void onPrepareShutdown(
     PrepareShutdown::Request::SharedPtr request, PrepareShutdown::Response::SharedPtr response);
+
+  /**
+   * @brief Callback for the service request to execute shutdown
+   * @param [in] request Service request
+   * @param [in] response Service response
+   */
   void onExecuteShutdown(
     ExecuteShutdown::Request::SharedPtr request, ExecuteShutdown::Response::SharedPtr response);
-  void onTopic(const std::shared_ptr<rclcpp::SerializedMessage> msg);
+
+  /**
+   * @brief Callback to check if ECU is running
+   * @param [in] message Topic to monitor
+   */
+  void onTopic(const std::shared_ptr<rclcpp::SerializedMessage> message);
+
+  /**
+   * @brief Timer callback to notify ECU state
+   */
   void onTimer();
+
+  /**
+   * @brief Check if startup completion
+   * @return true on running, false on not running
+   */
+  bool isRunning();
+
+  /**
+   * @brief Check if startup timer expired
+   * @return true on timer expired, false on not expired
+   */
   bool isStartupTimeout();
+
+  /**
+   * @brief Check if shutdown preparation timer expired
+   * @return true on timer expired, false on not expired
+   */
   bool isPreparationTimeout();
+
+  /**
+   * @brief Check if shutdown is ready
+   * @return true on shutdown ready, false on not ready
+   */
   bool isReady();
+
+  /**
+   * @brief Send request to boot-shutdown service
+   */
+  void sendPrepareShutdownRequest();
+
+  /**
+   * @brief Send request to boot-shutdown service
+   */
+  void sendExecuteShutdownRequest();
+
+  /**
+   * @brief Get status from boot-shutdown service
+   * @param [in] request Request to boot-shutdown service
+   * @param [out] status Status from boot-shutdown service
+   */
+  void getStatus(boot_shutdown_service::Request request, bool & status);
+
+  /**
+   * @brief Connect to boot-shutdown service
+   * @return true on success, false on error
+   */
+  bool connectService();
+
+  /**
+   * @brief Send data to boot-shutdown service
+   * @param [in] request Request to boot-shutdown service
+   * @return true on success, false on error
+   */
+  bool sendData(boot_shutdown_service::Request request);
+
+  /**
+   * @brief Send data to boot-shutdown service with parameters
+   * @param [in] request Request to boot-shutdown service
+   * @param [in] parameters List of parameters
+   * @return true on success, false on error
+   */
+  bool sendDataWithParameters(
+    boot_shutdown_service::Request request, std::vector<std::string> & parameters);
+
+  /**
+   * @brief Receive data from boot-shutdown service
+   * @param [out] status Status from boot-shutdown service
+   */
+  void receiveData(bool & status);
+
+  /**
+   * @brief Close connection with boot-shutdown service
+   */
+  void closeConnection();
 };
 
 }  // namespace boot_shutdown_interface

--- a/boot_shutdown_interface/launch/boot_shutdown.launch.xml
+++ b/boot_shutdown_interface/launch/boot_shutdown.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="ecu_name" default="ecu"/>
+  <arg name="ecu_name" default="$(env HOSTNAME default)"/>
   <arg name="boot_shutdown_param_path" default="$(find-pkg-share boot_shutdown_interface)/config/boot_shutdown.param.yaml"/>
 
   <group>

--- a/boot_shutdown_interface/src/boot_shutdown_interface.cpp
+++ b/boot_shutdown_interface/src/boot_shutdown_interface.cpp
@@ -14,98 +14,101 @@
 
 #include "boot_shutdown_interface/boot_shutdown_interface.hpp"
 
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/serialization/string.hpp>
+#include <boost/serialization/vector.hpp>
+
+#include <sys/socket.h>
+#include <sys/un.h>
+
+#include <climits>
+#include <regex>
+
 namespace boot_shutdown_interface
 {
-
 BootShutdownInterface::BootShutdownInterface(const rclcpp::NodeOptions & options)
 : Node("boot_shutdown", options),
-  ecu_name_(declare_parameter("ecu_name", std::string("ecu"))),
   startup_timeout_(declare_parameter("startup_timeout", 180)),
   prepare_shutdown_time_(declare_parameter("prepare_shutdown_time", 1)),
-  execute_shutdown_time_(declare_parameter("execute_shutdown_time", 13))
+  execute_shutdown_time_(declare_parameter("execute_shutdown_time", 13)),
+  commands_(declare_parameter("additional_prepare_shutdown_command", std::vector<std::string>())),
+  socket_path_(declare_parameter("socket_path", boot_shutdown_service::SOCKET_PATH)),
+  socket_(-1)
 {
   using namespace std::literals::chrono_literals;
   using std::placeholders::_1;
   using std::placeholders::_2;
 
-  ecu_state_.name = ecu_name_;
+  // Get hostname
+  char hostname[HOST_NAME_MAX + 1];
+  gethostname(hostname, sizeof(hostname));
+
+  ecu_state_.name = hostname;
   ecu_state_.state = EcuState::STARTUP;
   startup_time_ = get_clock()->now();
 
   srv_prepare_shutdown_ = create_service<PrepareShutdown>(
-    "~/service/prepare_shutdown", std::bind(
-      &BootShutdownInterface::onPrepareShutdown, this, _1,
-      _2),
-    rmw_qos_profile_default);
+    "~/service/prepare_shutdown",
+    std::bind(&BootShutdownInterface::onPrepareShutdown, this, _1, _2), rmw_qos_profile_default);
 
   srv_execute_shutdown_ = create_service<ExecuteShutdown>(
-    "~/service/execute_shutdown", std::bind(
-      &BootShutdownInterface::onExecuteShutdown, this, _1,
-      _2),
-    rmw_qos_profile_default);
+    "~/service/execute_shutdown",
+    std::bind(&BootShutdownInterface::onExecuteShutdown, this, _1, _2), rmw_qos_profile_default);
 
-  pub_ecu_state_ =
-    create_publisher<EcuState>("~/output/ecu_state", rclcpp::QoS{1});
+  pub_ecu_state_ = create_publisher<EcuState>("~/output/ecu_state", rclcpp::QoS{1});
 
   try {
     createTopicChecker();
   } catch (const std::exception & e) {
-    RCLCPP_INFO(get_logger(), "topic config is not set, set ecu state to running, ERROR: %s", e.what());
-    ecu_state_.state = EcuState::RUNNING;
+    RCLCPP_INFO(
+      get_logger(), "topic config is not set, set ecu state to running, ERROR: %s", e.what());
+    topic_received_ = true;
   }
 
-  timer_ = rclcpp::create_timer(
-    this, get_clock(), 1s, std::bind(&BootShutdownInterface::onTimer, this));
+  timer_ =
+    rclcpp::create_timer(this, get_clock(), 1s, std::bind(&BootShutdownInterface::onTimer, this));
 }
 
 void BootShutdownInterface::createTopicChecker()
 {
   auto qos = rclcpp::QoS{1};
-  if (declare_parameter(
-      "topic_config.transient_local",
-      static_cast<rclcpp::ParameterValue>(false)).get<bool>())
-  {
+  if (declare_parameter("topic_config.transient_local", static_cast<rclcpp::ParameterValue>(false))
+        .get<bool>()) {
     qos.transient_local();
   }
-  if (declare_parameter(
-      "topic_config.best_effort",
-      static_cast<rclcpp::ParameterValue>(false)).get<bool>())
-  {
+  if (declare_parameter("topic_config.best_effort", static_cast<rclcpp::ParameterValue>(false))
+        .get<bool>()) {
     qos.best_effort();
   }
 
   sub_topic_ = create_generic_subscription(
     declare_parameter("topic_config.name", rclcpp::PARAMETER_STRING).get<std::string>(),
-    declare_parameter("topic_config.type", rclcpp::PARAMETER_STRING).get<std::string>(),
-    qos, std::bind(&BootShutdownInterface::onTopic, this, std::placeholders::_1));
+    declare_parameter("topic_config.type", rclcpp::PARAMETER_STRING).get<std::string>(), qos,
+    std::bind(&BootShutdownInterface::onTopic, this, std::placeholders::_1));
 }
 
 void BootShutdownInterface::onPrepareShutdown(
   PrepareShutdown::Request::SharedPtr, PrepareShutdown::Response::SharedPtr response)
 {
-  RCLCPP_INFO(get_logger(), "shutdown preparing...");
+  RCLCPP_INFO(get_logger(), "Preparing Shutdown...");
 
-  // Clear pagecache, dentries, and inodes.
-  preparation_child_ = boost::process::child(
-    "/bin/sh", "-c",
-    "sync; echo 3 > /proc/sys/vm/drop_caches");
+  sendPrepareShutdownRequest();
 
   ecu_state_.state = EcuState::SHUTDOWN_PREPARING;
   prepare_shutdown_start_time_ = get_clock()->now();
 
   response->status.success = true;
-  response->power_off_time = prepare_shutdown_start_time_ + rclcpp::Duration(
-    prepare_shutdown_time_ + execute_shutdown_time_, 0);
+  response->power_off_time = prepare_shutdown_start_time_ +
+                             rclcpp::Duration(prepare_shutdown_time_ + execute_shutdown_time_, 0);
 }
 
 void BootShutdownInterface::onExecuteShutdown(
   ExecuteShutdown::Request::SharedPtr, ExecuteShutdown::Response::SharedPtr response)
 {
-  RCLCPP_INFO(get_logger(), "shutdown executing...");
+  RCLCPP_INFO(get_logger(), "Executing shutdown...");
 
-  // Shutdown
-  // Avoid using "now" and delay shutdown to publish ecu_state
-  shutdown_child_ = boost::process::child("/bin/sh", "-c", "shutdown -h now");
+  sendExecuteShutdownRequest();
 
   ecu_state_.power_off_time = get_clock()->now() + rclcpp::Duration(execute_shutdown_time_, 0);
   response->status.success = true;
@@ -115,18 +118,21 @@ void BootShutdownInterface::onExecuteShutdown(
 void BootShutdownInterface::onTopic(
   [[maybe_unused]] const std::shared_ptr<rclcpp::SerializedMessage> msg)
 {
-  if (ecu_state_.state == EcuState::STARTUP) {
-    ecu_state_.state = EcuState::RUNNING;
-  }
+  topic_received_ = true;
 }
 
 void BootShutdownInterface::onTimer()
 {
-  if (ecu_state_.state == EcuState::STARTUP) {
-    if (isStartupTimeout()) {
+  // allow recover from timeout
+  if (ecu_state_.state == EcuState::STARTUP || ecu_state_.state == EcuState::STARTUP_TIMEOUT) {
+    if (isRunning()) {
+      ecu_state_.state = EcuState::RUNNING;
+    } else if (isStartupTimeout()) {
       ecu_state_.state = EcuState::STARTUP_TIMEOUT;
     }
-  } else if (ecu_state_.state == EcuState::SHUTDOWN_PREPARING) {
+  } else if (
+    ecu_state_.state == EcuState::SHUTDOWN_PREPARING ||
+    ecu_state_.state == EcuState::SHUTDOWN_TIMEOUT) {
     if (isReady()) {
       ecu_state_.state = EcuState::SHUTDOWN_READY;
     } else if (isPreparationTimeout()) {
@@ -136,6 +142,8 @@ void BootShutdownInterface::onTimer()
 
   pub_ecu_state_->publish(ecu_state_);
 }
+
+bool BootShutdownInterface::isRunning() { return topic_received_; }
 
 bool BootShutdownInterface::isStartupTimeout()
 {
@@ -150,7 +158,154 @@ bool BootShutdownInterface::isPreparationTimeout()
 
 bool BootShutdownInterface::isReady()
 {
-  return !(preparation_child_.running());
+  bool status = true;
+  getStatus(boot_shutdown_service::IS_READY_TO_SHUTDOWN, status);
+  return status;
+}
+
+void BootShutdownInterface::sendPrepareShutdownRequest()
+{
+  // Connect to boot/shutdown service
+  if (!connectService()) {
+    closeConnection();
+    return;
+  }
+
+  // Send data to boot/shutdown service
+  if (!sendDataWithParameters(boot_shutdown_service::PREPARE_SHUTDOWN, commands_)) {
+    closeConnection();
+    return;
+  }
+
+  // Close connection with boot/shutdown service
+  closeConnection();
+}
+
+void BootShutdownInterface::sendExecuteShutdownRequest()
+{
+  // Connect to boot/shutdown service
+  if (!connectService()) {
+    closeConnection();
+    return;
+  }
+
+  // Send data to boot/shutdown service
+  if (!sendData(boot_shutdown_service::EXECUTE_SHUTDOWN)) {
+    closeConnection();
+    return;
+  }
+
+  // Close connection with boot/shutdown service
+  closeConnection();
+}
+
+void BootShutdownInterface::getStatus(boot_shutdown_service::Request request, bool & status)
+{
+  // Connect to boot/shutdown service
+  if (!connectService()) {
+    closeConnection();
+    return;
+  }
+
+  // Send data to boot/shutdown service
+  if (!sendData(request)) {
+    closeConnection();
+    return;
+  }
+
+  // Receive data from boot/shutdown service
+  receiveData(status);
+
+  // Close connection with boot/shutdown service
+  closeConnection();
+}
+
+bool BootShutdownInterface::connectService()
+{
+  // Create a new socket
+  socket_ = socket(AF_UNIX, SOCK_STREAM, 0);
+  if (socket_ < 0) {
+    RCLCPP_ERROR(get_logger(), "Failed to create a new socket. %s", strerror(errno));
+    return false;
+  }
+
+  sockaddr_un addr = {};
+  addr.sun_family = AF_UNIX;
+  strncpy(addr.sun_path, socket_path_.c_str(), sizeof(addr.sun_path) - 1);
+
+  int ret = connect(socket_, (struct sockaddr *)&addr, sizeof(addr));
+  if (ret < 0) {
+    RCLCPP_ERROR(get_logger(), "Failed to connect. %s", strerror(errno));
+    close(socket_);
+    return false;
+  }
+
+  return true;
+}
+
+bool BootShutdownInterface::sendData(boot_shutdown_service::Request request)
+{
+  std::ostringstream out_stream;
+  boost::archive::text_oarchive archive(out_stream);
+  archive & request;
+
+  int ret = write(socket_, out_stream.str().c_str(), out_stream.str().length());
+  if (ret < 0) {
+    RCLCPP_ERROR(get_logger(), "Failed to write N bytes of BUF to FD. %s", strerror(errno));
+    return false;
+  }
+
+  return true;
+}
+
+bool BootShutdownInterface::sendDataWithParameters(
+  boot_shutdown_service::Request request, std::vector<std::string> & parameters)
+{
+  std::ostringstream out_stream;
+  boost::archive::text_oarchive archive(out_stream);
+  archive & request;
+  archive & parameters;
+
+  int ret = write(socket_, out_stream.str().c_str(), out_stream.str().length());
+  if (ret < 0) {
+    RCLCPP_ERROR(get_logger(), "Failed to write N bytes of BUF to FD. %s", strerror(errno));
+    return false;
+  }
+
+  return true;
+}
+
+void BootShutdownInterface::receiveData(bool & status)
+{
+  char buffer[1024]{};
+  uint8_t request_id = boot_shutdown_service::Request::NONE;
+
+  int ret = recv(socket_, buffer, sizeof(buffer) - 1, 0);
+  if (ret < 0) {
+    RCLCPP_ERROR(get_logger(), "Failed to recv. %s", strerror(errno));
+    return;
+  }
+  // No data received
+  if (ret == 0) {
+    RCLCPP_ERROR(get_logger(), "No data received.");
+    return;
+  }
+
+  // Restore device status list
+  try {
+    std::istringstream in_stream(buffer);
+    boost::archive::text_iarchive archive(in_stream);
+    archive >> request_id;
+    archive >> status;
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR(get_logger(), "Failed to restore message. %s\n", e.what());
+  }
+}
+
+void BootShutdownInterface::closeConnection()
+{
+  // Close the file descriptor FD
+  close(socket_);
 }
 
 }  // namespace boot_shutdown_interface

--- a/boot_shutdown_service/CMakeLists.txt
+++ b/boot_shutdown_service/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.14)
+project(boot_shutdown_service)
+
+find_package(ament_cmake_auto REQUIRED)
+find_package(Boost REQUIRED COMPONENTS
+  serialization
+  system
+)
+
+ament_auto_find_build_dependencies()
+
+ament_auto_add_executable(boot_shutdown_service
+  src/boot_shutdown_main.cpp
+  src/boot_shutdown_service.cpp
+)
+
+target_link_libraries(boot_shutdown_service ${Boost_LIBRARIES} pthread)
+
+ament_auto_package()

--- a/boot_shutdown_service/README.md
+++ b/boot_shutdown_service/README.md
@@ -1,0 +1,3 @@
+# Boot Shutdown Service
+
+A daemon process to prepare and execute shutdown by receiving messages via UNIX domain socket.

--- a/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_common.hpp
+++ b/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_common.hpp
@@ -1,0 +1,32 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BOOT_SHUTDOWN_SERVICE__BOOT_SHUTDOWN_COMMON_HPP_
+#define BOOT_SHUTDOWN_SERVICE__BOOT_SHUTDOWN_COMMON_HPP_
+
+namespace boot_shutdown_service
+{
+
+static constexpr char SOCKET_PATH[] = "/tmp/boot_shutdown";
+
+enum Request {
+  NONE = 0,
+  PREPARE_SHUTDOWN,
+  EXECUTE_SHUTDOWN,
+  IS_READY_TO_SHUTDOWN,
+};
+
+}  // namespace boot_shutdown_service
+
+#endif  // BOOT_SHUTDOWN_SERVICE__BOOT_SHUTDOWN_COMMON_HPP_

--- a/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_service.hpp
+++ b/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_service.hpp
@@ -1,0 +1,86 @@
+// Copyright 2022 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BOOT_SHUTDOWN__SERVICE__BOOT_SHUTDOWN_SERVICE_HPP_
+#define BOOT_SHUTDOWN__SERVICE__BOOT_SHUTDOWN_SERVICE_HPP_
+
+#include "boot_shutdown_service/boot_shutdown_common.hpp"
+
+#include <boost/archive/text_iarchive.hpp>
+
+#include <mutex>
+#include <string>
+
+namespace boot_shutdown_service
+{
+
+class BootShutdownService
+{
+public:
+  /**
+   * @brief Constructor
+   * @param[in] socket_path Path of UNIX domain socket
+   */
+  explicit BootShutdownService(const std::string & socket_path);
+
+  /**
+   * @brief Initialization
+   * @return true on success, false on error
+   */
+  bool initialize();
+
+  /**
+   * @brief Shutdown
+   */
+  void shutdown();
+
+  /**
+   * @brief Main loop
+   */
+  void run();
+
+protected:
+  /**
+   * @brief Handle messsage
+   * @param[in] buffer Pointer to data received
+   */
+  void handleMessage(const char * buffer);
+
+  /**
+   * @brief Prepare shutdown
+   * @param[in] archive Archive object for loading
+   */
+  void prepareShutdown(boost::archive::text_iarchive & archive);
+
+  /**
+   * @brief Execute shutdown
+   */
+  void executeShutdown();
+
+  /**
+   * @brief Return if ready to execute shutdown or not
+   */
+  void isReadyToShutdown();
+
+  std::string socket_path_;  //!< @brief Path of UNIX domain socket
+  int port_;                 //!< @brief Port number to access l2ping service
+  int socket_;               //!< @brief Socket to communicate with ros node
+  int connection_;           //!< @brief Accepted socket for the incoming connection
+  std::mutex mutex_;         //!< @brief Mutex guard for the flag
+  bool is_ready_;            //!< @brief Ready to execute shutdown
+};
+
+}  // namespace boot_shutdown_service
+
+#endif  // BOOT_SHUTDOWN__SERVICE__BOOT_SHUTDOWN_SERVICE_HPP_

--- a/boot_shutdown_service/package.xml
+++ b/boot_shutdown_service/package.xml
@@ -1,20 +1,15 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>boot_shutdown_interface</name>
+  <name>boot_shutdown_service</name>
   <version>0.1.0</version>
-  <description>The boot_shutdown_interface package</description>
+  <description>The boot_shutdown_service package</description>
   <maintainer email="shinnosuke.hirakawa@tier4.jp">Shinnosuke Hirakawa</maintainer>
   <maintainer email="fumihito.ito@tier4.jp">Fumihito Ito</maintainer>
 
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
-  <depend>boot_shutdown_api_msgs</depend>
-  <depend>boot_shutdown_service</depend>
-  <depend>rclcpp</depend>
-  <depend>rclcpp_components</depend>
 
   <test_depend>ament_lint_auto</test_depend>
 

--- a/boot_shutdown_service/src/boot_shutdown_main.cpp
+++ b/boot_shutdown_service/src/boot_shutdown_main.cpp
@@ -1,0 +1,87 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "boot_shutdown_service/boot_shutdown_service.hpp"
+
+#include <errno.h>
+#include <getopt.h>
+#include <string.h>
+#include <syslog.h>
+#include <unistd.h>
+
+/**
+ * @brief Print usage
+ */
+void usage()
+{
+  printf("Usage: msr_reader [options]\n");
+  printf("  -h --help   : Display help\n");
+  printf("  -s --socket # : Path of UNIX domain socket.\n");
+  printf("\n");
+}
+
+int main(int argc, char ** argv)
+{
+  static struct option long_options[] = {
+    {"help", no_argument, 0, 'h'}, {"socket", required_argument, nullptr, 's'}, {0, 0, 0, 0}};
+
+  // Parse command-line options
+  int c = 0;
+  int option_index = 0;
+  std::string socket_path = boot_shutdown_service::SOCKET_PATH;
+
+  while ((c = getopt_long(argc, argv, "hs:", long_options, &option_index)) != -1) {
+    switch (c) {
+      case 'h':
+        usage();
+        return EXIT_SUCCESS;
+
+      case 's':
+        socket_path = optarg;
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  // Put the program in the background
+  if (daemon(0, 0) < 0) {
+    printf("Failed to put the program in the background. %s\n", strerror(errno));
+    return errno;
+  }
+
+  // Open connection to system logger
+  openlog(nullptr, LOG_PID, LOG_DAEMON);
+
+  // Initialize boot/shutdown service
+  boot_shutdown_service::BootShutdownService service(socket_path);
+
+  if (!service.initialize()) {
+    service.shutdown();
+    closelog();
+    return EXIT_FAILURE;
+  }
+
+  // Run main loop
+  service.run();
+
+  // Shutdown boot/shutdown service
+  service.shutdown();
+
+  // Close descriptor used to write to system logger
+  closelog();
+
+  return EXIT_SUCCESS;
+}

--- a/boot_shutdown_service/src/boot_shutdown_service.cpp
+++ b/boot_shutdown_service/src/boot_shutdown_service.cpp
@@ -1,0 +1,215 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "boot_shutdown_service/boot_shutdown_service.hpp"
+
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/process.hpp>
+#include <boost/serialization/string.hpp>
+#include <boost/serialization/vector.hpp>
+
+#include <errno.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <syslog.h>
+
+namespace boot_shutdown_service
+{
+
+BootShutdownService::BootShutdownService(const std::string & socket_path)
+: socket_path_(socket_path), socket_(-1), connection_(-1)
+{
+}
+
+bool BootShutdownService::initialize()
+{
+  // Remove previous binding
+  remove(socket_path_.c_str());
+
+  // Create a new socket
+  socket_ = socket(AF_UNIX, SOCK_STREAM, 0);
+  if (socket_ < 0) {
+    syslog(LOG_ERR, "Failed to create a new socket. %s\n", strerror(errno));
+    return false;
+  }
+
+  sockaddr_un addr = {};
+  addr.sun_family = AF_UNIX;
+  strncpy(addr.sun_path, socket_path_.c_str(), sizeof(addr.sun_path) - 1);
+
+  // Give the socket FD the unix domain socket
+  int ret = bind(socket_, (struct sockaddr *)&addr, sizeof(addr));
+  if (ret < 0) {
+    syslog(LOG_ERR, "Failed to give the socket FD the unix domain socket. %s\n", strerror(errno));
+    shutdown();
+    return false;
+  }
+
+  // Give permission to other users to access to socket
+  if (chmod(socket_path_.c_str(), S_IRWXU | S_IRWXG | S_IRWXO) != 0) {
+    syslog(LOG_ERR, "Failed to give permission to unix domain socket. %s\n", strerror(errno));
+    return false;
+  }
+
+  // Prepare to accept connections on socket FD
+  ret = listen(socket_, 5);
+  if (ret < 0) {
+    syslog(LOG_ERR, "Failed to prepare to accept connections on socket FD. %s\n", strerror(errno));
+    shutdown();
+    return false;
+  }
+
+  return true;
+}
+
+void BootShutdownService::shutdown() { close(socket_); }
+
+void BootShutdownService::run()
+{
+  sockaddr_un client = {};
+  socklen_t len = sizeof(client);
+
+  while (true) {
+    // Await a connection on socket FD
+    connection_ = accept(socket_, reinterpret_cast<sockaddr *>(&client), &len);
+    if (connection_ < 0) {
+      syslog(
+        LOG_ERR, "Failed to prepare to accept connections on socket FD. %s\n", strerror(errno));
+      close(connection_);
+      continue;
+    }
+
+    // Receive messages from a socket
+    char buffer[1024]{};
+    int ret = recv(connection_, buffer, sizeof(buffer) - 1, 0);
+    if (ret < 0) {
+      syslog(LOG_ERR, "Failed to recv. %s\n", strerror(errno));
+      close(connection_);
+      continue;
+    }
+    // No data received
+    if (ret == 0) {
+      syslog(LOG_ERR, "No data received.\n");
+      close(connection_);
+      continue;
+    }
+
+    // Handle message
+    handleMessage(buffer);
+
+    close(connection_);
+  }
+}
+
+void BootShutdownService::handleMessage(const char * buffer)
+{
+  uint8_t request_id = Request::NONE;
+
+  // Restore request from ros node
+  std::istringstream in_stream(buffer);
+  boost::archive::text_iarchive archive(in_stream);
+
+  try {
+    archive >> request_id;
+  } catch (const std::exception & e) {
+    syslog(LOG_ERR, "Failed to restore message. %s\n", e.what());
+    return;
+  }
+
+  switch (request_id) {
+    case Request::PREPARE_SHUTDOWN:
+      prepareShutdown(archive);
+      break;
+    case Request::EXECUTE_SHUTDOWN:
+      executeShutdown();
+      break;
+    case Request::IS_READY_TO_SHUTDOWN:
+      isReadyToShutdown();
+      break;
+    default:
+      syslog(LOG_WARNING, "Unknown message. %d\n", request_id);
+      break;
+  }
+}
+
+void BootShutdownService::prepareShutdown(boost::archive::text_iarchive & archive)
+{
+  is_ready_ = false;
+
+  syslog(LOG_INFO, "Preparing shutdown...");
+
+  std::vector<std::string> commands;
+  try {
+    archive >> commands;
+  } catch (const std::exception & e) {
+    syslog(LOG_ERR, "Failed to restore optional commands. %s\n", e.what());
+    commands.clear();
+  }
+
+  std::thread thread([this, commands] {
+    for (const auto & command : commands) {
+      if (!command.empty()) {
+        syslog(LOG_INFO, "Executing '%s'", command.c_str());
+        boost::process::child c("/bin/sh", "-c", command);
+        c.wait();
+      }
+    }
+    {
+      boost::process::child c("/bin/sh", "-c", "sync; echo 3 > /proc/sys/vm/drop_caches;");
+      c.wait();
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    is_ready_ = true;
+  });
+
+  thread.detach();
+}
+
+void BootShutdownService::executeShutdown()
+{
+  syslog(LOG_INFO, "Executing shutdown...");
+
+  std::thread thread([this] {
+    boost::process::child c("/bin/sh", "-c", "shutdown -h now");
+    c.wait();
+  });
+
+  thread.detach();
+}
+
+void BootShutdownService::isReadyToShutdown()
+{
+  bool is_ready = false;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    is_ready = is_ready_;
+  }
+
+  // Inform ros node
+  std::ostringstream out_stream;
+  boost::archive::text_oarchive archive(out_stream);
+  archive & Request::IS_READY_TO_SHUTDOWN;
+  archive & is_ready;
+
+  //  Write N bytes of BUF to FD
+  int ret = write(connection_, out_stream.str().c_str(), out_stream.str().length());
+  if (ret < 0) {
+    syslog(LOG_ERR, "Failed to write N bytes of BUF to FD. %s\n", strerror(errno));
+  }
+}
+
+}  // namespace boot_shutdown_service

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,41 @@
+ARG OVERLAY_WS=/opt/ros/overlay_ws
+ARG L4T_RELEASE=32
+ARG L4T_REVISION_MAJOR=6
+ARG L4T_REVISION_MINOR=1
+ARG L4T_VERSION=$L4T_RELEASE.$L4T_REVISION_MAJOR.$L4T_REVISION_MINOR
+
+FROM dustynv/ros:galactic-ros-base-l4t-r$L4T_VERSION AS base
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+         geographiclib-tools \
+         libfmt-dev \
+         libboost-dev \
+    && rm -rf /var/lib/apt/list/*
+
+
+FROM base AS builder
+
+ARG OVERLAY_WS
+WORKDIR $OVERLAY_WS/src
+
+COPY ./docker/overlay.repos ../
+RUN vcs import ./ < ../overlay.repos
+
+# build overlay source
+WORKDIR $OVERLAY_WS
+
+RUN . /opt/ros/$ROS_DISTRO/install/setup.sh && \
+    colcon build \
+        --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to boot_shutdown_interface
+
+ENV OVERLAY_WS=${OVERLAY_WS}
+
+# source entrypoint setup
+RUN sed --in-place --expression \
+      '$isource "$OVERLAY_WS/install/setup.bash"' \
+      /ros_entrypoint.sh
+
+ENTRYPOINT ["/ros_entrypoint.sh"]
+CMD ["bash"]
+WORKDIR /

--- a/docker/overlay.repos
+++ b/docker/overlay.repos
@@ -1,0 +1,18 @@
+repositories:
+  # core
+  core/autoware_adapi_msgs:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
+    version: main
+  core/autoware_common:
+    type: git
+    url: https://github.com/autowarefoundation/autoware_common.git
+    version: main
+  core/external/autoware_auto_msgs: # TODO(mfc): Remove when autoware_msgs is merged
+    type: git
+    url: https://github.com/tier4/autoware_auto_msgs.git
+    version: tier4/main
+  boot_shutdown_tools:
+    type: git
+    url: https://github.com/tier4/boot_shutdown_tools.git
+    version: feature/design_changes

--- a/docker/overlay.repos
+++ b/docker/overlay.repos
@@ -15,4 +15,4 @@ repositories:
   boot_shutdown_tools:
     type: git
     url: https://github.com/tier4/boot_shutdown_tools.git
-    version: feature/design_changes
+    version: main


### PR DESCRIPTION
Signed-off-by: ito-san <fumihito.ito@tier4.jp>

This is design changes to run `boot_shutdown_interface` ros node on the ECUs which do not have ROS in native host environment.

- `boot_shutdown_service`
  - Added daemon process running in native environment to prepare/execute shutdown.
- `boot_shutdown_interface`
  - Removed processing to prepare/execute shutdown and replaced with the processing to communicate with `boot_shutdown_service` via UNIX domain socket. 
  - Use `hostname` value for the ros namespace instead of `ecu_name` fed by ros parameter. 
- `docker`
   - Added Dockerfile to build docker image on ROScubeX to run `boot_shutdown_interface`.