### PR TITLE
feat: add webauto service client

### DIFF
--- a/boot_shutdown_manager/include/boot_shutdown_manager/boot_shutdown_manager_core.hpp
+++ b/boot_shutdown_manager/include/boot_shutdown_manager/boot_shutdown_manager_core.hpp
@@ -16,6 +16,7 @@
 #define BOOT_SHUTDOWN_MANAGER__BOOT_SHUTDOWN_MANAGER_HPP_
 
 #include <rclcpp/rclcpp.hpp>
+#include <std_srvs/srv/set_bool.hpp>
 #include <tier4_api_utils/tier4_api_utils.hpp>
 
 #include <boot_shutdown_api_msgs/msg/ecu_state.hpp>
@@ -49,6 +50,8 @@ public:
 private:
   rclcpp::Publisher<EcuStateSummary>::SharedPtr pub_ecu_state_summary_;
   tier4_api_utils::Service<Shutdown>::SharedPtr srv_shutdown;
+  tier4_api_utils::Client<std_srvs::srv::SetBool>::SharedPtr cli_webauto_;
+
   rclcpp::TimerBase::SharedPtr timer_;
 
   rclcpp::CallbackGroup::SharedPtr callback_group_;

--- a/boot_shutdown_manager/package.xml
+++ b/boot_shutdown_manager/package.xml
@@ -15,6 +15,7 @@
   <depend>fmt</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>std_srvs</depend>
   <depend>tier4_api_utils</depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
- `shutdown prepare`のタイミングで、/webauto/shutdownのserviceを利用しFMSへ通知するAPIを追加