### PR TITLE
fix(boot_shutdown_service): support build on non-ROS2 environment

### DIFF
--- a/boot_shutdown_service/CMakeLists.noros2
+++ b/boot_shutdown_service/CMakeLists.noros2
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.10.2)
+project(boot_shutdown_service)
+
+add_definitions(-DBOOST_ERROR_CODE_HEADER_ONLY)
+
+find_package(Boost REQUIRED COMPONENTS
+  serialization
+
+)
+
+add_executable(boot_shutdown_service
+  src/boot_shutdown_main.cpp
+  src/boot_shutdown_service.cpp
+)
+
+include_directories(include)
+
+target_link_libraries(boot_shutdown_service ${Boost_LIBRARIES} pthread)
+
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)

--- a/boot_shutdown_service/CMakeLists.noros2
+++ b/boot_shutdown_service/CMakeLists.noros2
@@ -18,7 +18,5 @@ include_directories(include)
 target_link_libraries(boot_shutdown_service ${Boost_LIBRARIES} pthread)
 
 install(TARGETS ${PROJECT_NAME}
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )

--- a/boot_shutdown_service/CMakeLists.ros2
+++ b/boot_shutdown_service/CMakeLists.ros2
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.14)
+project(boot_shutdown_service)
+
+find_package(ament_cmake_auto REQUIRED)
+find_package(Boost REQUIRED COMPONENTS
+  serialization
+  system
+)
+
+ament_auto_find_build_dependencies()
+
+ament_auto_add_executable(boot_shutdown_service
+  src/boot_shutdown_main.cpp
+  src/boot_shutdown_service.cpp
+)
+
+target_link_libraries(boot_shutdown_service ${Boost_LIBRARIES} pthread)
+
+ament_auto_package()

--- a/boot_shutdown_service/CMakeLists.txt
+++ b/boot_shutdown_service/CMakeLists.txt
@@ -1,19 +1,9 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.10.2)
 project(boot_shutdown_service)
 
-find_package(ament_cmake_auto REQUIRED)
-find_package(Boost REQUIRED COMPONENTS
-  serialization
-  system
-)
-
-ament_auto_find_build_dependencies()
-
-ament_auto_add_executable(boot_shutdown_service
-  src/boot_shutdown_main.cpp
-  src/boot_shutdown_service.cpp
-)
-
-target_link_libraries(boot_shutdown_service ${Boost_LIBRARIES} pthread)
-
-ament_auto_package()
+find_program(ROS2 "ros2")
+if (ROS2)
+ include(CMakeLists.ros2)
+else()
+ include(CMakeLists.noros2)
+endif()


### PR DESCRIPTION
Signed-off-by: ito-san <fumihito.ito@tier4.jp>

The daemon executable `boot_shutdown_service` which actually  prepares/executes shutdown itself is built with ROS2 docker environment and copied to the host OS from docker container.
However, Autoware Evaluator is unable to run docker container and `docker cp` with CI/CD build system, so the executable `boot_shutdown_service` should be built on the host OS.

On the non ROS2 environment, the following steps are needed to build.
```console
mkdir build
cmake ..
sudo cmake --build . --target install
```

This has been verified on perception and media streaming ECU.

```console
ros@RQX-58G:~/boot_shutdown_tools/boot_shutdown_service$ mkdir build
ros@RQX-58G:~/boot_shutdown_tools/boot_shutdown_service$ cd build/
ros@RQX-58G:~/boot_shutdown_tools/boot_shutdown_service/build$ cmake  ..
-- The C compiler identification is GNU 7.5.0
-- The CXX compiler identification is GNU 7.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Boost version: 1.65.1
-- Found the following Boost libraries:
--   serialization
-- Configuring done
-- Generating done
-- Build files have been written to: /home/ros/boot_shutdown_tools/boot_shutdown_service/build
ros@RQX-58G:~/boot_shutdown_tools/boot_shutdown_service/build$ sudo cmake --build . --target install
Scanning dependencies of target boot_shutdown_service
[ 33%] Building CXX object CMakeFiles/boot_shutdown_service.dir/src/boot_shutdown_main.cpp.o
[ 66%] Building CXX object CMakeFiles/boot_shutdown_service.dir/src/boot_shutdown_service.cpp.o
[100%] Linking CXX executable boot_shutdown_service
[100%] Built target boot_shutdown_service
Install the project...
-- Install configuration: ""
-- Installing: /usr/local/bin/boot_shutdown_service
ros@RQX-58G:~/boot_shutdown_tools/boot_shutdown_service/build$ which boot_shutdown_service 
/usr/local/bin/boot_shutdown_service

```