### PR TITLE
fix(docker): allow to override build docker image for perception ECU

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,11 +1,9 @@
 ARG OVERLAY_WS=/opt/ros/overlay_ws
-ARG L4T_RELEASE=32
-ARG L4T_REVISION_MAJOR=6
-ARG L4T_REVISION_MINOR=1
-ARG L4T_VERSION=$L4T_RELEASE.$L4T_REVISION_MAJOR.$L4T_REVISION_MINOR
-ARG L4T_IMAGE=dustynv/ros:galactic-ros-base-l4t-r$L4T_VERSION
+ARG BASE_REPOSITORY=dustynv/ros
+ARG BASE_TAG=galactic-ros-base-l4t-r32.6.1
+ARG BASE_IMAGE=$BASE_REPOSITORY:$BASE_TAG
 
-FROM $L4T_IMAGE AS base
+FROM $BASE_IMAGE AS base
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -13,9 +11,6 @@ RUN apt-get update \
          libfmt-dev \
          libboost-dev \
     && rm -rf /var/lib/apt/list/*
-
-
-FROM base AS builder
 
 ARG OVERLAY_WS
 WORKDIR $OVERLAY_WS/src

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,8 +3,9 @@ ARG L4T_RELEASE=32
 ARG L4T_REVISION_MAJOR=6
 ARG L4T_REVISION_MINOR=1
 ARG L4T_VERSION=$L4T_RELEASE.$L4T_REVISION_MAJOR.$L4T_REVISION_MINOR
+ARG L4T_IMAGE=dustynv/ros:galactic-ros-base-l4t-r$L4T_VERSION
 
-FROM dustynv/ros:galactic-ros-base-l4t-r$L4T_VERSION AS base
+FROM $L4T_IMAGE AS base
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -27,7 +28,7 @@ WORKDIR $OVERLAY_WS
 
 RUN . /opt/ros/$ROS_DISTRO/install/setup.sh && \
     colcon build \
-        --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to boot_shutdown_interface
+        --cmake-args -DCMAKE_BUILD_TYPE=Release --merge-install --packages-up-to boot_shutdown_interface
 
 ENV OVERLAY_WS=${OVERLAY_WS}
 


### PR DESCRIPTION
Multiple docker images are not allowed to be built and used on Autoware Evaluator.
The perception ECU already builds and uses a docker image named `jetson-container`, so we need to include boot_shutdown_interface node into the docker image and build override the docker image `jetson-container`.

cf. https://star4.slack.com/archives/CRUE57C30/p1669099534330569?thread_ts=1668420613.788089&cid=CRUE57C30 

This is to add docker ARG `BASE_IMAGE` including repository and tag and used for `FROM` statement.