### PR TITLE
fix: fix kitware key

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,6 +5,10 @@ ARG BASE_IMAGE=$BASE_REPOSITORY:$BASE_TAG
 
 FROM $BASE_IMAGE AS base
 
+RUN wget -q -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null \
+    && echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main' | tee /etc/apt/sources.list.d/kitware.list >/dev/null \
+    && sed -i 's|deb https://apt.kitware.com/ubuntu/ bionic main|#&|g' /etc/apt/sources.list
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
          geographiclib-tools \


### PR DESCRIPTION
https://github.com/tier4/jetson_iv_container/pull/29
と同様の修正を入れます。
```
https://github.com/NVIDIA-ISAAC-ROS/isaac_ros_common/issues/50
に有るように、kitwareのapt keyが変わったようで、最新の鍵を取り込みます。
手元ではaptのエラーがでなくなりました。
```