### PR TITLE
feat(boot_shutdown_manager): publish unknown state

### DIFF
--- a/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
+++ b/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
@@ -116,6 +116,7 @@ BootShutdownManager::BootShutdownManager()
         [this, client](const EcuState::SharedPtr msg) { client->ecu_state = msg; });
       client->ecu_state = std::make_shared<EcuState>();
       client->ecu_state->state = EcuState::UNKNOWN;
+      client->ecu_state->name = ecu_name;
     }
     ecu_client_map_.insert({ecu_name, client});
 

--- a/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
+++ b/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
@@ -114,6 +114,8 @@ BootShutdownManager::BootShutdownManager()
       client->sub_ecu_state = create_subscription<EcuState>(
         state_topic_name, rclcpp::QoS{1},
         [this, client](const EcuState::SharedPtr msg) { client->ecu_state = msg; });
+      client->ecu_state = std::make_shared<EcuState>();
+      client->ecu_state->state = EcuState::UNKNOWN;
     }
     ecu_client_map_.insert({ecu_name, client});
 
@@ -206,9 +208,7 @@ void BootShutdownManager::onTimer()
   // Update detail
   ecu_state_summary_.details.clear();
   for (auto & [ecu_name, client] : ecu_client_map_) {
-    if (client->ecu_state) {
-      ecu_state_summary_.details.push_back(*client->ecu_state);
-    }
+    ecu_state_summary_.details.push_back(*client->ecu_state);
   }
 
   pub_ecu_state_summary_->publish(ecu_state_summary_);
@@ -217,7 +217,7 @@ void BootShutdownManager::onTimer()
 bool BootShutdownManager::isRunning() const
 {
   for (const auto & [ecu_name, client] : ecu_client_map_) {
-    if (!client->ecu_state || client->ecu_state->state != EcuState::RUNNING) {
+    if (client->ecu_state->state != EcuState::RUNNING) {
       return false;
     }
   }
@@ -230,7 +230,7 @@ bool BootShutdownManager::isReady() const
     if (client->skip_shutdown) {
       continue;
     }
-    if (!client->ecu_state || client->ecu_state->state != EcuState::SHUTDOWN_READY) {
+    if (client->ecu_state->state != EcuState::SHUTDOWN_READY) {
       return false;
     }
   }


### PR DESCRIPTION
This PR changes the behavior until receiving the first state.
Before: Do not include information for ECUs that have not yet received the first state.
After: Until receiving the first state from each ECU, insert {state: UNKNOWN, name: {ECU_name}} in the summary.

```
$ ros2 topic echo /pilot_auto/api/ecu/state
---
summary:
  state: 1
  name: ''
  message: ''
  power_off_time:
    sec: 0
    nanosec: 0
details:
- state: 0
  name: logging
  message: ''
  power_off_time:
    sec: 0
    nanosec: 0
- state: 0
  name: mot
  message: ''
  power_off_time:
    sec: 0
    nanosec: 0
```