### PR TITLE
feat(boot_shutdown_manager): add primary flag

### DIFF
--- a/boot_shutdown_manager/config/boot_shutdown_manager.param.yaml
+++ b/boot_shutdown_manager/config/boot_shutdown_manager.param.yaml
@@ -11,6 +11,7 @@
 #   state: /{ecu_name}/get/ecu_state
 #   prepare: /api/{ecu_name}/prepare_shutdown
 #   execute: /api/{ecu_name}/execute_shutdown
+#   primary: false
 #   skip_shutdown: false
 ---
 /**:
@@ -23,6 +24,7 @@
         state: /autoware_ecu/get/ecu_state
         prepare: /api/autoware_ecu/prepare_shutdown
         execute: /api/autoware_ecu/execute_shutdown
+        primary: true
       mot:
         skip_shutdown: true 
       logging: default

--- a/boot_shutdown_manager/include/boot_shutdown_manager/boot_shutdown_manager_core.hpp
+++ b/boot_shutdown_manager/include/boot_shutdown_manager/boot_shutdown_manager_core.hpp
@@ -24,6 +24,8 @@
 #include <boot_shutdown_api_msgs/srv/prepare_shutdown.hpp>
 #include <boot_shutdown_api_msgs/srv/shutdown.hpp>
 
+#include <deque>
+
 namespace boot_shutdown_manager
 {
 using boot_shutdown_api_msgs::msg::EcuState;
@@ -38,6 +40,7 @@ struct EcuClient
   rclcpp::Subscription<EcuState>::SharedPtr sub_ecu_state;
   rclcpp::Client<ExecuteShutdown>::SharedPtr cli_execute;
   rclcpp::Client<PrepareShutdown>::SharedPtr cli_prepare;
+  bool primary;
   bool skip_shutdown;
 };
 
@@ -56,7 +59,7 @@ private:
   rclcpp::CallbackGroup::SharedPtr callback_group_;
 
   EcuStateSummary ecu_state_summary_;
-  std::map<std::string, std::shared_ptr<EcuClient>> ecu_client_map_;
+  std::deque<std::pair<std::string, std::shared_ptr<EcuClient>>> ecu_client_queue_;
   rclcpp::Time last_transition_stamp_;
   double update_rate_;
   double startup_timeout_;


### PR DESCRIPTION
- Add `primary` flag to specify ECU to run boot_shutdown_manager
  - the ECU with `primary` flag enabled are now the last to be shutdown 