### PR TITLE
fix(docker): specify version of repositories in overlay.repos

### DIFF
--- a/docker/overlay.repos
+++ b/docker/overlay.repos
@@ -3,16 +3,16 @@ repositories:
   core/autoware_adapi_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_adapi_msgs.git
-    version: main
+    version: d049f403698749eaf2dccfad37a2e586fd916200
   core/autoware_common:
     type: git
     url: https://github.com/autowarefoundation/autoware_common.git
-    version: main
+    version: 06abffda1b1fbaac51f17e1c3f9e27e6ab115eb6
   core/external/autoware_auto_msgs: # TODO(mfc): Remove when autoware_msgs is merged
     type: git
     url: https://github.com/tier4/autoware_auto_msgs.git
-    version: tier4/main
+    version: 6b5bc4365f9a2fc913bc11afa74ec21ffa2dbf32
   boot_shutdown_tools:
     type: git
     url: https://github.com/tier4/boot_shutdown_tools.git
-    version: main
+    version: v0.1.1


### PR DESCRIPTION
MS ECUのビルドエラーに対応するPRです。
https://star4.slack.com/archives/CRUE57C30/p1687152383411309