### PR TITLE
fix(docker): change repository url in overlay.repos

### DIFF
--- a/docker/overlay.repos
+++ b/docker/overlay.repos
@@ -6,7 +6,7 @@ repositories:
     version: d049f403698749eaf2dccfad37a2e586fd916200
   core/autoware_common:
     type: git
-    url: https://github.com/autowarefoundation/autoware_common.git
+    url: https://github.com/tier4/autoware_common.git
     version: 06abffda1b1fbaac51f17e1c3f9e27e6ab115eb6
   core/external/autoware_auto_msgs: # TODO(mfc): Remove when autoware_msgs is merged
     type: git


### PR DESCRIPTION
https://github.com/tier4/boot_shutdown_tools/pull/21
こちらの修正が不十分でしたので対応いたしました。