### PR TITLE
fix(boot_shutdown_manager): fix strange state transition

### DIFF
--- a/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
+++ b/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
@@ -180,9 +180,12 @@ void BootShutdownManager::onForceShutdownService(
 {
   RCLCPP_INFO(get_logger(), "ForceShutdown start");
 
-  is_force_shutdown_ = true;
-
   onShutdownService(request, response);
+
+  // Enforce notification of SHUTDOWN_PREPARING
+  pub_ecu_state_summary_->publish(ecu_state_summary_);
+
+  is_force_shutdown_ = true;
 
   response->status.success = true;
 }


### PR DESCRIPTION
- There is an issue where, after receiving a forced shutdown request, boot_shutdown_manager transitions to SHUTDOWN_READY and then transitions to SHUTDOWN_PREPARING.
This strange state transition prevents the MOT side from completing the shutdown process successfully.

- The MOT requires the transition from SHUTDOWN_PREPARING to SHUTDOWN_READY. I have also added to send SHUTDOWN_PREPARING immediately.

```console
 onTimer(): state transioned : -> RUNNING
 onShutdownService(): PrepareShutdown start
 onShutdownService(): [signage1] PrepareShutdown service call faild.
 onShutdownService(): state transioned : -> SHUTDOWN_PREPARING
 onForceShutdownService(): ForceShutdown start
 onShutdownService(): PrepareShutdown start
 onShutdownService(): [signage1] PrepareShutdown service call faild.
 onTimer(): state transioned : -> SHUTDOWN_READY
 executeShutdown(): ExecuteShutdown start
 onShutdownService(): state transioned : -> SHUTDOWN_PREPARING
 executeShutdown(): [signage1] ExecuteShutdown service call faild.
 Stopping Boot Shutdown Manager...
```

Verified the transition from SHUTDOWN_PREPARING to SHUTDOWN_READY.
```console
 onTimer(): state transioned : -> RUNNING
 onShutdownService(): PrepareShutdown start
 onShutdownService(): [signage1] PrepareShutdown service call faild.
 onShutdownService(): webauto shutdown service call faild.
 onShutdownService(): state transioned : -> SHUTDOWN_PREPARING
 onForceShutdownService(): ForceShutdown start
 onShutdownService(): PrepareShutdown start
 onShutdownService(): [signage1] PrepareShutdown service call faild.
 onShutdownService(): state transioned : -> SHUTDOWN_PREPARING
 onTimer(): state transioned : -> SHUTDOWN_READY
 executeShutdown(): ExecuteShutdown start
 executeShutdown(): [signage1] ExecuteShutdown service call faild.
 Stopping Boot Shutdown Manager...
```