### PR TITLE
feat: migrate autoware msg

### DIFF
--- a/boot_shutdown_interface/config/boot_shutdown.param.yaml
+++ b/boot_shutdown_interface/config/boot_shutdown.param.yaml
@@ -6,7 +6,7 @@
 
     topic_config:
       name: "/autoware/state"
-      type: "autoware_auto_system_msgs/msg/AutowareState"
+      type: "autoware_system_msgs/msg/AutowareState"
       transient_local: False
       best_effort: False
 


### PR DESCRIPTION
autoware_msgへの移行に伴い、boot_shutdownでsubscribeするメッセージ型を変更します。
変更箇所はここだけで良かったでしょうか？
実機でboot_shutdownがsubscribeするメッセージ型が変わっていることは確認しました。