### PR TITLE
feat(boot_shutdown_internal_msgs): add non-ROS messages

### DIFF
--- a/boot_shutdown_internal_msgs/CMakeLists.txt
+++ b/boot_shutdown_internal_msgs/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.10.2)
+project(boot_shutdown_internal_msgs)
+
+add_library(${PROJECT_NAME} INTERFACE)
+
+target_include_directories(${PROJECT_NAME} INTERFACE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+
+target_compile_definitions(${PROJECT_NAME} INTERFACE
+  BOOST_ERROR_CODE_HEADER_ONLY
+)
+
+install(TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
+
+install(
+  EXPORT export_${PROJECT_NAME}
+  DESTINATION share/${PROJECT_NAME}/cmake
+  NAMESPACE "${PROJECT_NAME}::"
+  FILE "export_${PROJECT_NAME}Export.cmake"
+)

--- a/boot_shutdown_internal_msgs/CMakeLists.txt
+++ b/boot_shutdown_internal_msgs/CMakeLists.txt
@@ -8,10 +8,6 @@ target_include_directories(${PROJECT_NAME} INTERFACE
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
 
-target_compile_definitions(${PROJECT_NAME} INTERFACE
-  BOOST_ERROR_CODE_HEADER_ONLY
-)
-
 install(TARGETS ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}
   LIBRARY DESTINATION lib

--- a/boot_shutdown_internal_msgs/CMakeLists.txt
+++ b/boot_shutdown_internal_msgs/CMakeLists.txt
@@ -14,10 +14,3 @@ install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
 )
 install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
-
-install(
-  EXPORT export_${PROJECT_NAME}
-  DESTINATION share/${PROJECT_NAME}/cmake
-  NAMESPACE "${PROJECT_NAME}::"
-  FILE "export_${PROJECT_NAME}Export.cmake"
-)

--- a/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/msg/ecu_state_message.hpp
+++ b/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/msg/ecu_state_message.hpp
@@ -44,33 +44,33 @@ public:
   EcuStateMessage(
     EcuStateType state, const std::string & name, const std::string & message,
     std::chrono::system_clock::time_point power_off_time)
-  : state_(state), name_(name), message_(message), power_off_time_(power_off_time)
+  : state(state), name(name), message(message), power_off_time(power_off_time)
   {
   }
 
   template <class Archive>
   void serialize(Archive & ar, const unsigned int version)
   {
-    ar & state_;
-    ar & name_;
-    ar & message_;
+    ar & state;
+    ar & name;
+    ar & message;
     if (Archive::is_loading::value) {
       long long ms_since_epoch;
       ar & ms_since_epoch;
-      power_off_time_ =
+      power_off_time =
         std::chrono::system_clock::time_point(std::chrono::milliseconds(ms_since_epoch));
     } else {
       auto ms_since_epoch =
-        std::chrono::duration_cast<std::chrono::milliseconds>(power_off_time_.time_since_epoch())
+        std::chrono::duration_cast<std::chrono::milliseconds>(power_off_time.time_since_epoch())
           .count();
       ar & ms_since_epoch;
     }
   }
 
-  EcuStateType state_;
-  std::string name_;
-  std::string message_;
-  std::chrono::system_clock::time_point power_off_time_;
+  EcuStateType state;
+  std::string name;
+  std::string message;
+  std::chrono::system_clock::time_point power_off_time;
 };
 
 }  // namespace msg

--- a/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/msg/ecu_state_message.hpp
+++ b/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/msg/ecu_state_message.hpp
@@ -27,7 +27,7 @@ namespace boot_shutdown_internal_msgs
 namespace msg
 {
 
-enum EcuState {
+enum EcuStateType {
   UNKNOWN = 0,
   STARTUP = 1,
   RUNNING = 2,
@@ -42,9 +42,9 @@ class EcuStateMessage
 public:
   EcuStateMessage() = default;
   EcuStateMessage(
-    EcuState state, const std::string & message,
+    EcuStateType state, const std::string & name, const std::string & message,
     std::chrono::system_clock::time_point power_off_time)
-  : state_(state), message_(message), power_off_time_(power_off_time)
+  : state_(state), name_(name), message_(message), power_off_time_(power_off_time)
   {
   }
 
@@ -52,6 +52,7 @@ public:
   void serialize(Archive & ar, const unsigned int version)
   {
     ar & state_;
+    ar & name_;
     ar & message_;
     if (Archive::is_loading::value) {
       long long ms_since_epoch;
@@ -66,7 +67,8 @@ public:
     }
   }
 
-  EcuState state_;
+  EcuStateType state_;
+  std::string name_;
   std::string message_;
   std::chrono::system_clock::time_point power_off_time_;
 };

--- a/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/msg/ecu_state_message.hpp
+++ b/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/msg/ecu_state_message.hpp
@@ -1,0 +1,78 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BOOT_SHUTDOWN_INTERNAL_MSGS_ECU_STATE_MESSAGE_HPP_
+#define BOOT_SHUTDOWN_INTERNAL_MSGS_ECU_STATE_MESSAGE_HPP_
+
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+
+#include <chrono>
+#include <sstream>
+
+namespace boot_shutdown_internal_msgs
+{
+
+namespace msg
+{
+
+enum EcuState {
+  UNKNOWN = 0,
+  STARTUP = 1,
+  RUNNING = 2,
+  SHUTDOWN_PREPARING = 3,
+  SHUTDOWN_READY = 4,
+  STARTUP_TIMEOUT = 1001,
+  SHUTDOWN_TIMEOUT = 1002,
+};
+
+class EcuStateMessage
+{
+public:
+  EcuStateMessage() = default;
+  EcuStateMessage(
+    EcuState state, const std::string & message,
+    std::chrono::system_clock::time_point power_off_time)
+  : state_(state), message_(message), power_off_time_(power_off_time)
+  {
+  }
+
+  template <class Archive>
+  void serialize(Archive & ar, const unsigned int version)
+  {
+    ar & state_;
+    ar & message_;
+    if (Archive::is_loading::value) {
+      long long ms_since_epoch;
+      ar & ms_since_epoch;
+      power_off_time_ =
+        std::chrono::system_clock::time_point(std::chrono::milliseconds(ms_since_epoch));
+    } else {
+      auto ms_since_epoch =
+        std::chrono::duration_cast<std::chrono::milliseconds>(power_off_time_.time_since_epoch())
+          .count();
+      ar & ms_since_epoch;
+    }
+  }
+
+  EcuState state_;
+  std::string message_;
+  std::chrono::system_clock::time_point power_off_time_;
+};
+
+}  // namespace msg
+
+}  // namespace boot_shutdown_internal_msgs
+
+#endif  // BOOT_SHUTDOWN_INTERNAL_MSGS_ECU_STATE_MESSAGE_HPP_

--- a/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/msg/response_status.hpp
+++ b/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/msg/response_status.hpp
@@ -1,0 +1,66 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BOOT_SHUTDOWN_INTERNAL_MSGS_REPOSNSE_STATUS_HPP_
+#define BOOT_SHUTDOWN_INTERNAL_MSGS_REPOSNSE_STATUS_HPP_
+
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+
+#include <chrono>
+#include <sstream>
+
+namespace boot_shutdown_internal_msgs
+{
+
+namespace msg
+{
+
+enum Code {
+  SERVICE_UNKNOWN = 50000,
+  SERVICE_UNREADY = 50001,
+  SERVICE_TIMEOUT = 50002,
+  TRANSFORM_ERROR = 50003,
+  PARAMETER_ERROR = 50004,
+  DEPRECATED = 60000,
+  NO_EFFECT = 60001,
+};
+
+class ResponseStatus
+{
+public:
+  ResponseStatus() = default;
+  ResponseStatus(bool success, Code code, const std::string & message)
+  : success_(success), code_(code), message_(message)
+  {
+  }
+
+  template <class Archive>
+  void serialize(Archive & ar, const unsigned int version)
+  {
+    ar & success_;
+    ar & code_;
+    ar & message_;
+  }
+
+  bool success_;
+  Code code_;
+  std::string message_;
+};
+
+}  // namespace msg
+
+}  // namespace boot_shutdown_internal_msgs
+
+#endif  // BOOT_SHUTDOWN_INTERNAL_MSGS_REPOSNSE_STATUS_HPP_

--- a/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/msg/response_status.hpp
+++ b/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/msg/response_status.hpp
@@ -54,7 +54,7 @@ public:
     ar & message;
   }
 
-  bool success;
+  int success;
   Code code;
   std::string message;
 };

--- a/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/msg/response_status.hpp
+++ b/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/msg/response_status.hpp
@@ -42,21 +42,21 @@ class ResponseStatus
 public:
   ResponseStatus() = default;
   ResponseStatus(bool success, Code code, const std::string & message)
-  : success_(success), code_(code), message_(message)
+  : success(success), code(code), message(message)
   {
   }
 
   template <class Archive>
   void serialize(Archive & ar, const unsigned int version)
   {
-    ar & success_;
-    ar & code_;
-    ar & message_;
+    ar & success;
+    ar & code;
+    ar & message;
   }
 
-  bool success_;
-  Code code_;
-  std::string message_;
+  bool success;
+  Code code;
+  std::string message;
 };
 
 }  // namespace msg

--- a/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/srv/execute_shutdown_service.hpp
+++ b/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/srv/execute_shutdown_service.hpp
@@ -1,0 +1,69 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BOOT_SHUTDOWN_INTERNAL_MSGS_EXECUTE_SHUTDOWN_SERVICE_HPP_
+#define BOOT_SHUTDOWN_INTERNAL_MSGS_EXECUTE_SHUTDOWN_SERVICE_HPP_
+
+#include "boot_shutdown_internal_msgs/msg/response_status.hpp"
+
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+
+#include <chrono>
+#include <sstream>
+
+namespace boot_shutdown_internal_msgs
+{
+
+namespace srv
+{
+
+using boot_shutdown_internal_msgs::msg::ResponseStatus;
+
+class ExecuteShutdownService
+{
+public:
+  ExecuteShutdownService() = default;
+  ExecuteShutdownService(
+    ResponseStatus status, std::chrono::system_clock::time_point power_off_time)
+  : status_(status), power_off_time_(power_off_time)
+  {
+  }
+
+  template <class Archive>
+  void serialize(Archive & ar, const unsigned int version)
+  {
+    ar & status_;
+    if (Archive::is_loading::value) {
+      long long ms_since_epoch;
+      ar & ms_since_epoch;
+      power_off_time_ =
+        std::chrono::system_clock::time_point(std::chrono::milliseconds(ms_since_epoch));
+    } else {
+      auto ms_since_epoch =
+        std::chrono::duration_cast<std::chrono::milliseconds>(power_off_time_.time_since_epoch())
+          .count();
+      ar & ms_since_epoch;
+    }
+  }
+
+  ResponseStatus status_;
+  std::chrono::system_clock::time_point power_off_time_;
+};
+
+}  // namespace srv
+
+}  // namespace boot_shutdown_internal_msgs
+
+#endif  // BOOT_SHUTDOWN_INTERNAL_MSGS_EXECUTE_SHUTDOWN_SERVICE_HPP_

--- a/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/srv/execute_shutdown_service.hpp
+++ b/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/srv/execute_shutdown_service.hpp
@@ -37,29 +37,29 @@ public:
   ExecuteShutdownService() = default;
   ExecuteShutdownService(
     ResponseStatus status, std::chrono::system_clock::time_point power_off_time)
-  : status_(status), power_off_time_(power_off_time)
+  : status(status), power_off_time(power_off_time)
   {
   }
 
   template <class Archive>
   void serialize(Archive & ar, const unsigned int version)
   {
-    ar & status_;
+    ar & status;
     if (Archive::is_loading::value) {
       long long ms_since_epoch;
       ar & ms_since_epoch;
-      power_off_time_ =
+      power_off_time =
         std::chrono::system_clock::time_point(std::chrono::milliseconds(ms_since_epoch));
     } else {
       auto ms_since_epoch =
-        std::chrono::duration_cast<std::chrono::milliseconds>(power_off_time_.time_since_epoch())
+        std::chrono::duration_cast<std::chrono::milliseconds>(power_off_time.time_since_epoch())
           .count();
       ar & ms_since_epoch;
     }
   }
 
-  ResponseStatus status_;
-  std::chrono::system_clock::time_point power_off_time_;
+  ResponseStatus status;
+  std::chrono::system_clock::time_point power_off_time;
 };
 
 }  // namespace srv

--- a/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/srv/prepare_shutdown_service.hpp
+++ b/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/srv/prepare_shutdown_service.hpp
@@ -1,0 +1,69 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BOOT_SHUTDOWN_INTERNAL_MSGS_PREPARE_SHUTDOWN_SERVICE_HPP_
+#define BOOT_SHUTDOWN_INTERNAL_MSGS_PREPARE_SHUTDOWN_SERVICE_HPP_
+
+#include "boot_shutdown_internal_msgs/msg/response_status.hpp"
+
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+
+#include <chrono>
+#include <sstream>
+
+namespace boot_shutdown_internal_msgs
+{
+
+namespace srv
+{
+
+using boot_shutdown_internal_msgs::msg::ResponseStatus;
+
+class PrepareShutdownService
+{
+public:
+  PrepareShutdownService() = default;
+  PrepareShutdownService(
+    ResponseStatus status, std::chrono::system_clock::time_point power_off_time)
+  : status_(status), power_off_time_(power_off_time)
+  {
+  }
+
+  template <class Archive>
+  void serialize(Archive & ar, const unsigned int version)
+  {
+    ar & status_;
+    if (Archive::is_loading::value) {
+      long long ms_since_epoch;
+      ar & ms_since_epoch;
+      power_off_time_ =
+        std::chrono::system_clock::time_point(std::chrono::milliseconds(ms_since_epoch));
+    } else {
+      auto ms_since_epoch =
+        std::chrono::duration_cast<std::chrono::milliseconds>(power_off_time_.time_since_epoch())
+          .count();
+      ar & ms_since_epoch;
+    }
+  }
+
+  ResponseStatus status_;
+  std::chrono::system_clock::time_point power_off_time_;
+};
+
+}  // namespace srv
+
+}  // namespace boot_shutdown_internal_msgs
+
+#endif  // BOOT_SHUTDOWN_INTERNAL_MSGS_PREPARE_SHUTDOWN_SERVICE_HPP_

--- a/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/srv/prepare_shutdown_service.hpp
+++ b/boot_shutdown_internal_msgs/include/boot_shutdown_internal_msgs/srv/prepare_shutdown_service.hpp
@@ -37,29 +37,29 @@ public:
   PrepareShutdownService() = default;
   PrepareShutdownService(
     ResponseStatus status, std::chrono::system_clock::time_point power_off_time)
-  : status_(status), power_off_time_(power_off_time)
+  : status(status), power_off_time(power_off_time)
   {
   }
 
   template <class Archive>
   void serialize(Archive & ar, const unsigned int version)
   {
-    ar & status_;
+    ar & status;
     if (Archive::is_loading::value) {
       long long ms_since_epoch;
       ar & ms_since_epoch;
-      power_off_time_ =
+      power_off_time =
         std::chrono::system_clock::time_point(std::chrono::milliseconds(ms_since_epoch));
     } else {
       auto ms_since_epoch =
-        std::chrono::duration_cast<std::chrono::milliseconds>(power_off_time_.time_since_epoch())
+        std::chrono::duration_cast<std::chrono::milliseconds>(power_off_time.time_since_epoch())
           .count();
       ar & ms_since_epoch;
     }
   }
 
-  ResponseStatus status_;
-  std::chrono::system_clock::time_point power_off_time_;
+  ResponseStatus status;
+  std::chrono::system_clock::time_point power_off_time;
 };
 
 }  // namespace srv

--- a/boot_shutdown_internal_msgs/package.xml
+++ b/boot_shutdown_internal_msgs/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>boot_shutdown_internal_msgs</name>
+  <version>0.1.0</version>
+  <description>The boot_shutdown_internal_msgs package</description>
+  <maintainer email="fumihito.ito@tier4.jp">Fumihito Ito</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <depend>boost</depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
## Description

Modify the boot and shutdown message exchange between ECUs to remove the dependency on ROS. 
This PR defines message structures that are independent of ROS.

## Tests performed

Not applicable.

## Effects on system behavior

Not applicable.

## Interface changes
### Messages to replace ROS2 topics
1. `EcuStateMessage`: `/{ecu_name}/get/ecu_state`
2. `ResponseStatus`: included in `EcuStateMessage`

### Messages to replace ROS2 services
1. `PrepareShutdownService`: `/api/{ecu_name}/prepare_shutdown`
2. `ExecuteShutdownService`: `/api/{ecu_name}/execute_shutdown`
