### PR TITLE
feat(boot_shutdown_manager): remove ROS dependency from ECU communication

### DIFF
--- a/boot_shutdown_manager/CMakeLists.txt
+++ b/boot_shutdown_manager/CMakeLists.txt
@@ -29,34 +29,3 @@ ament_auto_package(
     config
     launch
 )
-cmake_minimum_required(VERSION 3.14)
-project(boot_shutdown_manager)
-
-find_package(ament_cmake_auto REQUIRED)
-find_package(Boost REQUIRED COMPONENTS
-  serialization
-)
-
-ament_auto_find_build_dependencies()
-
-ament_auto_add_executable(boot_shutdown_manager
-  src/boot_shutdown_manager_core.cpp
-  src/boot_shutdown_manager_node.cpp
-)
-
-target_include_directories(boot_shutdown_manager PUBLIC
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../boot_shutdown_internal_msgs/include>"
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../boot_shutdown_udp/include>"
-  "$<INSTALL_INTERFACE:include/boot_shutdown_internal_msgs>"
-  "$<INSTALL_INTERFACE:include/boot_shutdown_udp>"
-)
-
-target_link_libraries(boot_shutdown_manager
-  Boost::serialization
-)
-
-ament_auto_package(
-  INSTALL_TO_SHARE
-    config
-    launch
-)

--- a/boot_shutdown_manager/CMakeLists.txt
+++ b/boot_shutdown_manager/CMakeLists.txt
@@ -15,9 +15,9 @@ ament_auto_add_executable(boot_shutdown_manager
 
 target_include_directories(boot_shutdown_manager PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../boot_shutdown_internal_msgs/include>"
-  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../boot_shutdown_udp/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../boot_shutdown_communication/include>"
   "$<INSTALL_INTERFACE:include/boot_shutdown_internal_msgs>"
-  "$<INSTALL_INTERFACE:include/boot_shutdown_udp>"
+  "$<INSTALL_INTERFACE:include/boot_shutdown_communication>"
 )
 
 target_link_libraries(boot_shutdown_manager

--- a/boot_shutdown_manager/CMakeLists.txt
+++ b/boot_shutdown_manager/CMakeLists.txt
@@ -2,13 +2,57 @@ cmake_minimum_required(VERSION 3.14)
 project(boot_shutdown_manager)
 
 find_package(ament_cmake_auto REQUIRED)
+find_package(Boost REQUIRED COMPONENTS
+  serialization
+)
 
 ament_auto_find_build_dependencies()
-
 
 ament_auto_add_executable(boot_shutdown_manager
   src/boot_shutdown_manager_core.cpp
   src/boot_shutdown_manager_node.cpp
+)
+
+target_include_directories(boot_shutdown_manager PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../boot_shutdown_internal_msgs/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../boot_shutdown_udp/include>"
+  "$<INSTALL_INTERFACE:include/boot_shutdown_internal_msgs>"
+  "$<INSTALL_INTERFACE:include/boot_shutdown_udp>"
+)
+
+target_link_libraries(boot_shutdown_manager
+  Boost::serialization
+)
+
+ament_auto_package(
+  INSTALL_TO_SHARE
+    config
+    launch
+)
+cmake_minimum_required(VERSION 3.14)
+project(boot_shutdown_manager)
+
+find_package(ament_cmake_auto REQUIRED)
+find_package(Boost REQUIRED COMPONENTS
+  serialization
+)
+
+ament_auto_find_build_dependencies()
+
+ament_auto_add_executable(boot_shutdown_manager
+  src/boot_shutdown_manager_core.cpp
+  src/boot_shutdown_manager_node.cpp
+)
+
+target_include_directories(boot_shutdown_manager PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../boot_shutdown_internal_msgs/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../boot_shutdown_udp/include>"
+  "$<INSTALL_INTERFACE:include/boot_shutdown_internal_msgs>"
+  "$<INSTALL_INTERFACE:include/boot_shutdown_udp>"
+)
+
+target_link_libraries(boot_shutdown_manager
+  Boost::serialization
 )
 
 ament_auto_package(

--- a/boot_shutdown_manager/config/boot_shutdown_manager.param.yaml
+++ b/boot_shutdown_manager/config/boot_shutdown_manager.param.yaml
@@ -19,6 +19,9 @@
     update_rate: 1.0
     startup_timeout: 60.0
     preparation_timeout: 10.0
+    server_port_: 10000
+    server_timeout: 1
+    publisher_port: 10001
     managed_ecu:
       autoware_ecu:
         state: /autoware_ecu/get/ecu_state

--- a/boot_shutdown_manager/config/boot_shutdown_manager.param.yaml
+++ b/boot_shutdown_manager/config/boot_shutdown_manager.param.yaml
@@ -5,6 +5,9 @@
 #       prepare: {PrepareShutdown service name}
 #       execute: {Executeshutdown service name}
 #       skip_shutdown: {when true, the manager do not execute shutdown for this unit}
+#       service_address: nNetwork address used to interact with the ECU’s shutdown-related services
+#       prepare_shutdown_port: Port number used for the shutdown preparation service of the ECU
+#       execute_shutdown_port: Port number used for the shutdown execution service of the ECU
 #
 # Note:
 # default values are:
@@ -13,21 +16,25 @@
 #   execute: /api/{ecu_name}/execute_shutdown
 #   primary: false
 #   skip_shutdown: false
+#   service_address: 127.0.0.1
+#   prepare_shutdown_port: 10001
+#   execute_shutdown_port: 10002
 ---
 /**:
   ros__parameters:
     update_rate: 1.0
     startup_timeout: 60.0
     preparation_timeout: 10.0
-    server_port_: 10000
-    server_timeout: 1
-    publisher_port: 10001
+    topic_port: 10000
+    service_timeout: 1
     managed_ecu:
       autoware_ecu:
         state: /autoware_ecu/get/ecu_state
         prepare: /api/autoware_ecu/prepare_shutdown
         execute: /api/autoware_ecu/execute_shutdown
         primary: true
+        service_address: 192.168.20.11
       mot:
         skip_shutdown: true 
-      logging: default
+      logging:
+        service_address: 192.168.20.71

--- a/boot_shutdown_manager/include/boot_shutdown_manager/boot_shutdown_manager_core.hpp
+++ b/boot_shutdown_manager/include/boot_shutdown_manager/boot_shutdown_manager_core.hpp
@@ -15,14 +15,22 @@
 #ifndef BOOT_SHUTDOWN_MANAGER__BOOT_SHUTDOWN_MANAGER_HPP_
 #define BOOT_SHUTDOWN_MANAGER__BOOT_SHUTDOWN_MANAGER_HPP_
 
-#include <rclcpp/rclcpp.hpp>
-#include <std_srvs/srv/set_bool.hpp>
+#include "boot_shutdown_udp/service_client.hpp"
+#include "boot_shutdown_udp/topic_subscriber.hpp"
 
+#include <rclcpp/rclcpp.hpp>
+
+#include "boot_shutdown_internal_msgs/msg/ecu_state_message.hpp"
+#include "boot_shutdown_internal_msgs/srv/execute_shutdown_service.hpp"
+#include "boot_shutdown_internal_msgs/srv/prepare_shutdown_service.hpp"
 #include <boot_shutdown_api_msgs/msg/ecu_state.hpp>
 #include <boot_shutdown_api_msgs/msg/ecu_state_summary.hpp>
 #include <boot_shutdown_api_msgs/srv/execute_shutdown.hpp>
 #include <boot_shutdown_api_msgs/srv/prepare_shutdown.hpp>
 #include <boot_shutdown_api_msgs/srv/shutdown.hpp>
+#include <std_srvs/srv/set_bool.hpp>
+
+#include <boost/asio.hpp>
 
 #include <deque>
 
@@ -30,16 +38,21 @@ namespace boot_shutdown_manager
 {
 using boot_shutdown_api_msgs::msg::EcuState;
 using boot_shutdown_api_msgs::msg::EcuStateSummary;
-using boot_shutdown_api_msgs::srv::ExecuteShutdown;
-using boot_shutdown_api_msgs::srv::PrepareShutdown;
 using boot_shutdown_api_msgs::srv::Shutdown;
+
+using boot_shutdown_internal_msgs::srv::ExecuteShutdownService;
+using boot_shutdown_internal_msgs::srv::PrepareShutdownService;
+using boot_shutdown_udp::ServiceClient;
+using boot_shutdown_udp::TopicSubscriber;
+using boot_shutdown_internal_msgs::msg::EcuStateType;
+using boot_shutdown_internal_msgs::msg::EcuStateMessage;
 
 struct EcuClient
 {
-  EcuState::SharedPtr ecu_state;
-  rclcpp::Subscription<EcuState>::SharedPtr sub_ecu_state;
-  rclcpp::Client<ExecuteShutdown>::SharedPtr cli_execute;
-  rclcpp::Client<PrepareShutdown>::SharedPtr cli_prepare;
+  EcuStateMessage ecu_state;
+  TopicSubscriber<EcuStateMessage>::SharedPtr sub_ecu_state;
+  ServiceClient<ExecuteShutdownService>::SharedPtr cli_execute;
+  ServiceClient<PrepareShutdownService>::SharedPtr cli_prepare;
   bool primary;
   bool skip_shutdown;
 };
@@ -48,6 +61,7 @@ class BootShutdownManager : public rclcpp::Node
 {
 public:
   BootShutdownManager();
+  ~BootShutdownManager();
 
 private:
   rclcpp::Publisher<EcuStateSummary>::SharedPtr pub_ecu_state_summary_;
@@ -67,6 +81,8 @@ private:
   double preparation_timeout_;
   bool is_shutting_down;
   bool is_force_shutdown_;
+  boost::asio::io_context io_context_;
+  std::thread io_thread_;
 
   void onShutdownService(
     Shutdown::Request::SharedPtr request, Shutdown::Response::SharedPtr response);
@@ -77,6 +93,8 @@ private:
   bool isRunning() const;
   bool isReady() const;
   void executeShutdown();
+
+  rclcpp::Time convertToRclcppTime(const std::chrono::system_clock::time_point &time_point);
 };
 
 }  // namespace boot_shutdown_manager

--- a/boot_shutdown_manager/include/boot_shutdown_manager/boot_shutdown_manager_core.hpp
+++ b/boot_shutdown_manager/include/boot_shutdown_manager/boot_shutdown_manager_core.hpp
@@ -15,8 +15,8 @@
 #ifndef BOOT_SHUTDOWN_MANAGER__BOOT_SHUTDOWN_MANAGER_HPP_
 #define BOOT_SHUTDOWN_MANAGER__BOOT_SHUTDOWN_MANAGER_HPP_
 
-#include "boot_shutdown_udp/service_client.hpp"
-#include "boot_shutdown_udp/topic_subscriber.hpp"
+#include "boot_shutdown_communication/service_client.hpp"
+#include "boot_shutdown_communication/topic_subscriber.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 
@@ -44,8 +44,8 @@ using boot_shutdown_internal_msgs::msg::EcuStateMessage;
 using boot_shutdown_internal_msgs::msg::EcuStateType;
 using boot_shutdown_internal_msgs::srv::ExecuteShutdownService;
 using boot_shutdown_internal_msgs::srv::PrepareShutdownService;
-using boot_shutdown_udp::ServiceClient;
-using boot_shutdown_udp::TopicSubscriber;
+using boot_shutdown_communication::ServiceClient;
+using boot_shutdown_communication::TopicSubscriber;
 
 struct EcuClient
 {

--- a/boot_shutdown_manager/include/boot_shutdown_manager/boot_shutdown_manager_core.hpp
+++ b/boot_shutdown_manager/include/boot_shutdown_manager/boot_shutdown_manager_core.hpp
@@ -40,12 +40,12 @@ using boot_shutdown_api_msgs::msg::EcuState;
 using boot_shutdown_api_msgs::msg::EcuStateSummary;
 using boot_shutdown_api_msgs::srv::Shutdown;
 
+using boot_shutdown_communication::ServiceClient;
+using boot_shutdown_communication::TopicSubscriber;
 using boot_shutdown_internal_msgs::msg::EcuStateMessage;
 using boot_shutdown_internal_msgs::msg::EcuStateType;
 using boot_shutdown_internal_msgs::srv::ExecuteShutdownService;
 using boot_shutdown_internal_msgs::srv::PrepareShutdownService;
-using boot_shutdown_communication::ServiceClient;
-using boot_shutdown_communication::TopicSubscriber;
 
 struct EcuClient
 {
@@ -84,9 +84,8 @@ private:
 
   boost::asio::io_context io_context_;
   std::thread io_thread_;
-  unsigned short server_port_;
-  int server_timeout_;
-  unsigned short publisher_port_;
+  unsigned short topic_port_;
+  int service_timeout_;
 
   void onShutdownService(
     Shutdown::Request::SharedPtr request, Shutdown::Response::SharedPtr response);

--- a/boot_shutdown_manager/include/boot_shutdown_manager/boot_shutdown_manager_core.hpp
+++ b/boot_shutdown_manager/include/boot_shutdown_manager/boot_shutdown_manager_core.hpp
@@ -40,12 +40,12 @@ using boot_shutdown_api_msgs::msg::EcuState;
 using boot_shutdown_api_msgs::msg::EcuStateSummary;
 using boot_shutdown_api_msgs::srv::Shutdown;
 
+using boot_shutdown_internal_msgs::msg::EcuStateMessage;
+using boot_shutdown_internal_msgs::msg::EcuStateType;
 using boot_shutdown_internal_msgs::srv::ExecuteShutdownService;
 using boot_shutdown_internal_msgs::srv::PrepareShutdownService;
 using boot_shutdown_udp::ServiceClient;
 using boot_shutdown_udp::TopicSubscriber;
-using boot_shutdown_internal_msgs::msg::EcuStateType;
-using boot_shutdown_internal_msgs::msg::EcuStateMessage;
 
 struct EcuClient
 {
@@ -81,8 +81,12 @@ private:
   double preparation_timeout_;
   bool is_shutting_down;
   bool is_force_shutdown_;
+
   boost::asio::io_context io_context_;
   std::thread io_thread_;
+  unsigned short server_port_;
+  int server_timeout_;
+  unsigned short publisher_port_;
 
   void onShutdownService(
     Shutdown::Request::SharedPtr request, Shutdown::Response::SharedPtr response);
@@ -94,7 +98,7 @@ private:
   bool isReady() const;
   void executeShutdown();
 
-  rclcpp::Time convertToRclcppTime(const std::chrono::system_clock::time_point &time_point);
+  rclcpp::Time convertToRclcppTime(const std::chrono::system_clock::time_point & time_point);
 };
 
 }  // namespace boot_shutdown_manager

--- a/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
+++ b/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
@@ -126,6 +126,7 @@ BootShutdownManager::BootShutdownManager()
 
     auto client = std::make_shared<EcuClient>();
     {
+      client->primary = primary;
       client->skip_shutdown = skip_shutdown;
       client->cli_execute = ServiceClient<ExecuteShutdownService>::create_client(
         execute_service_name, io_context_, service_address, execute_shutdown_port,

--- a/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
+++ b/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
@@ -182,6 +182,10 @@ void BootShutdownManager::onShutdownService(
     try {
       PrepareShutdownService req;
       auto resp = client->cli_prepare->call(req);
+      if (!resp) {
+        RCLCPP_WARN(get_logger(), "Empty response.");
+        continue;
+      }
     } catch (const std::runtime_error & e) {
       RCLCPP_WARN(get_logger(), "Error: %s", e.what());
     } catch (...) {
@@ -322,6 +326,10 @@ void BootShutdownManager::executeShutdown()
     try {
       ExecuteShutdownService req;
       auto resp = client->cli_execute->call(req);
+      if (!resp) {
+        RCLCPP_WARN(get_logger(), "Empty response.");
+        continue;
+      }
       rclcpp::Time power_off_time = convertToRclcppTime(resp.power_off_time);
       if (latest_power_off_time < power_off_time) {
         latest_power_off_time = power_off_time;

--- a/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
+++ b/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
@@ -182,6 +182,10 @@ void BootShutdownManager::onShutdownService(
     try {
       PrepareShutdownService req;
       auto resp = client->cli_prepare->call(req);
+      if (!resp) {
+        RCLCPP_WARN(get_logger(), "prepare shutdown service call faild.");
+        continue;
+      }
     } catch (const std::runtime_error & e) {
       RCLCPP_WARN(get_logger(), "Error: %s", e.what());
     } catch (...) {
@@ -322,7 +326,11 @@ void BootShutdownManager::executeShutdown()
     try {
       ExecuteShutdownService req;
       auto resp = client->cli_execute->call(req);
-      rclcpp::Time power_off_time = convertToRclcppTime(resp.power_off_time);
+      if (!resp) {
+        RCLCPP_WARN(get_logger(), "execute shutdown service call faild.");
+        continue;
+      }
+      rclcpp::Time power_off_time = convertToRclcppTime(resp->power_off_time);
       if (latest_power_off_time < power_off_time) {
         latest_power_off_time = power_off_time;
       }

--- a/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
+++ b/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
@@ -182,10 +182,6 @@ void BootShutdownManager::onShutdownService(
     try {
       PrepareShutdownService req;
       auto resp = client->cli_prepare->call(req);
-      if (!resp) {
-        RCLCPP_WARN(get_logger(), "Empty response.");
-        continue;
-      }
     } catch (const std::runtime_error & e) {
       RCLCPP_WARN(get_logger(), "Error: %s", e.what());
     } catch (...) {
@@ -326,10 +322,6 @@ void BootShutdownManager::executeShutdown()
     try {
       ExecuteShutdownService req;
       auto resp = client->cli_execute->call(req);
-      if (!resp) {
-        RCLCPP_WARN(get_logger(), "Empty response.");
-        continue;
-      }
       rclcpp::Time power_off_time = convertToRclcppTime(resp.power_off_time);
       if (latest_power_off_time < power_off_time) {
         latest_power_off_time = power_off_time;


### PR DESCRIPTION
## Description

Modify the boot and shutdown message exchange between ECUs to remove the dependency on ROS. 
This PR updates the code to exchange messages that are independent of ROS from ECU communication.

The following PRs need to be merged before merging this PR.

* [x]  https://github.com/tier4/boot_shutdown_tools/pull/26
* [x]  https://github.com/tier4/boot_shutdown_tools/pull/27
* [x]  https://github.com/tier4/boot_shutdown_tools/pull/28
* [x]  https://github.com/tier4/boot_shutdown_tools/pull/29

## Tests performed

- Confirmed that the boot shutdown function works in the QEMU virtual environment for both Main and Sub ECUs.
- Confirmed that the force shutdown function works when the Sub ECU is not running.

## Effects on system behavior

Not applicable.

## Interface changes

Not applicable.
