### PR TITLE
feat(localhost_shutdown): add functionality to shutdown localhost

### DIFF
--- a/localhost_shutdown/CMakeLists.txt
+++ b/localhost_shutdown/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.10.2)
+project(localhost_shutdown)
+
+find_package(Boost REQUIRED COMPONENTS
+  serialization
+)
+find_package(Threads REQUIRED)
+
+add_executable(${PROJECT_NAME}
+  src/localhost_shutdown.cpp
+  src/localhost_shutdown_main.cpp
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../boot_shutdown_internal_msgs/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../boot_shutdown_communication/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+  "$<INSTALL_INTERFACE:include/boot_shutdown_internal_msgs>"
+  "$<INSTALL_INTERFACE:include/boot_shutdown_communication>"
+)
+
+target_compile_definitions(${PROJECT_NAME} PRIVATE
+  BOOST_ERROR_CODE_HEADER_ONLY
+)
+
+target_link_libraries(${PROJECT_NAME}
+  Boost::serialization
+  Threads::Threads
+  pthread
+)
+
+install(TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  RUNTIME DESTINATION bin
+)
+
+install(
+  EXPORT export_${PROJECT_NAME}
+  DESTINATION share/${PROJECT_NAME}/cmake
+  NAMESPACE "${PROJECT_NAME}::"
+  FILE "export_${PROJECT_NAME}Export.cmake"
+)

--- a/localhost_shutdown/README.md
+++ b/localhost_shutdown/README.md
@@ -1,0 +1,1 @@
+# Localhost Shutdown

--- a/localhost_shutdown/cmake/localhost_shutdownConfig.cmake
+++ b/localhost_shutdown/cmake/localhost_shutdownConfig.cmake
@@ -1,0 +1,19 @@
+# prevent multiple inclusion
+if(_localhost_shutdown_CONFIG_INCLUDED)
+  # ensure to keep the found flag the same
+  if(NOT DEFINED localhost_shutdown_FOUND)
+    # explicitly set it to FALSE, otherwise CMake will set it to TRUE
+    set(localhost_shutdown_FOUND FALSE)
+  elseif(NOT localhost_shutdown_FOUND)
+    # use separate condition to avoid uninitialized variable warning
+    set(localhost_shutdown_FOUND FALSE)
+  endif()
+  return()
+endif()
+set(_localhost_shutdown_CONFIG_INCLUDED TRUE)
+
+# include all config extra files
+set(_extras "export_localhost_shutdownExport.cmake")
+foreach(_extra ${_extras})
+  include("${localhost_shutdown_DIR}/${_extra}")
+endforeach()

--- a/localhost_shutdown/include/localhost_shutdown/localhost_shutdown.hpp
+++ b/localhost_shutdown/include/localhost_shutdown/localhost_shutdown.hpp
@@ -1,0 +1,56 @@
+// Copyright 2022 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BOOT_SHUTDOWN__SERVICE__LOCALHOST_SHUTDOWN_HPP_
+#define BOOT_SHUTDOWN__SERVICE__LOCALHOST_SHUTDOWN_HPP_
+
+#include "boot_shutdown_communication/service_client.hpp"
+
+#include "boot_shutdown_internal_msgs/srv/execute_shutdown_service.hpp"
+#include "boot_shutdown_internal_msgs/srv/prepare_shutdown_service.hpp"
+
+#include <boost/asio.hpp>
+
+namespace boot_shutdown_service
+{
+
+using boot_shutdown_communication::ServiceClient;
+using boot_shutdown_internal_msgs::srv::ExecuteShutdownService;
+using boot_shutdown_internal_msgs::srv::PrepareShutdownService;
+
+class LocalhostShutdown
+{
+public:
+  LocalhostShutdown();
+  void initialize();
+  void run();
+
+protected:
+  void prepareShutdown();
+  void executeShutdown();
+
+  std::string service_address_;
+  int service_timeout_;
+  unsigned short prepare_shutdown_port_;
+  unsigned short execute_shutdown_port_;
+
+  ServiceClient<ExecuteShutdownService>::SharedPtr cli_execute_;
+  ServiceClient<PrepareShutdownService>::SharedPtr cli_prepare_;
+
+  boost::asio::io_context io_context_;
+};
+
+}  // namespace boot_shutdown_service
+
+#endif  // BOOT_SHUTDOWN__SERVICE__LOCALHOST_SHUTDOWN_HPP_

--- a/localhost_shutdown/package.xml
+++ b/localhost_shutdown/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>localhost_shutdown</name>
+  <version>0.1.0</version>
+  <description>The localhost_shutdown package</description>
+  <maintainer email="fumihito.ito@tier4.jp">Fumihito Ito</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>cmake</buildtool_depend>
+
+  <depend>boost</depend>
+
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>

--- a/localhost_shutdown/src/localhost_shutdown.cpp
+++ b/localhost_shutdown/src/localhost_shutdown.cpp
@@ -1,0 +1,80 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "localhost_shutdown/localhost_shutdown.hpp"
+
+#include <iostream>
+
+#define FMT_HEADER_ONLY
+#include <fmt/format.h>
+
+namespace boot_shutdown_service
+{
+
+LocalhostShutdown::LocalhostShutdown()
+: service_address_(std::string("127.0.0.1")),
+  service_timeout_(1),
+  prepare_shutdown_port_(10001),
+  execute_shutdown_port_(10002)
+{
+}
+
+void LocalhostShutdown::initialize()
+{
+  char hostname[HOST_NAME_MAX + 1];
+  gethostname(hostname, sizeof(hostname));
+
+  std::replace(hostname, hostname + sizeof(hostname), '-', '_');
+
+  const std::string prepare_service_name = fmt::format("/api/{}/prepare_shutdown", hostname);
+  const std::string execute_service_name = fmt::format("/api/{}/execute_shutdown", hostname);
+
+  cli_execute_ = ServiceClient<ExecuteShutdownService>::create_client(
+    execute_service_name, io_context_, service_address_, execute_shutdown_port_, service_timeout_);
+  cli_prepare_ = ServiceClient<PrepareShutdownService>::create_client(
+    prepare_service_name, io_context_, service_address_, prepare_shutdown_port_, service_timeout_);
+}
+
+void LocalhostShutdown::run()
+{
+  prepareShutdown();
+  executeShutdown();
+  io_context_.run();
+}
+
+void LocalhostShutdown::prepareShutdown()
+{
+  try {
+    PrepareShutdownService req;
+    auto resp = cli_prepare_->call(req);
+  } catch (const std::runtime_error & e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+  } catch (...) {
+    std::cerr << "Unknown error occurred." << std::endl;
+  }
+}
+
+void LocalhostShutdown::executeShutdown()
+{
+  try {
+    ExecuteShutdownService req;
+    auto resp = cli_execute_->call(req);
+  } catch (const std::runtime_error & e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+  } catch (...) {
+    std::cerr << "Unknown error occurred." << std::endl;
+  }
+}
+
+}  // namespace boot_shutdown_service

--- a/localhost_shutdown/src/localhost_shutdown_main.cpp
+++ b/localhost_shutdown/src/localhost_shutdown_main.cpp
@@ -1,0 +1,27 @@
+// Copyright 2022 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "localhost_shutdown/localhost_shutdown.hpp"
+
+#include <errno.h>
+
+int main(int argc, char ** argv)
+{
+  boot_shutdown_service::LocalhostShutdown shutdown;
+
+  shutdown.initialize();
+  shutdown.run();
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
The MOT ECU uses ROS2 service calls to shut down itself.
However, ROS2 service calls cannot be used since the ECU's shutdown is no longer dependent on ROS.
Therefore, an executable must be provided to execute shutdown request defined in `boot_shutdown_internal_msgs`.

```
ros2 service call /api/mot/execute_shutdown boot_shutdown_api_msgs/srv/ExecuteShutdown {}
```