### PR TITLE
fix(boot_shutdown_service): fix power_off_time not set

### DIFF
--- a/boot_shutdown_service/src/boot_shutdown_service.cpp
+++ b/boot_shutdown_service/src/boot_shutdown_service.cpp
@@ -113,6 +113,7 @@ void BootShutdownService::onPrepareShutdown(
       std::chrono::seconds(prepare_shutdown_time_ + execute_shutdown_time_);
   
     setTimestamp(response.mutable_power_off_time(), power_off_time);
+    setTimestamp(ecu_state_.mutable_power_off_time(), power_off_time);
   }
 
   prepareShutdown();


### PR DESCRIPTION
## Description

The boot-shutdown-manager did not set power_off_time correctly when notifying MOT.
The issue was caused by each ECU's boot-shutdown-service not notifying the power_off_time. 
To resolve this, I added a process to set the power_off_time in each topic that each ECU periodically publishes.

[TIER IV INTERNAL JIRA LINK](https://tier4.atlassian.net/browse/RT0-35585)

## Tests performed

Verify that that the power_off_time in the summary is correctly set.
| Before the fix | After the fix |
| -------- | -------- |
| ![Screenshot from 2025-03-07 09-17-58](https://github.com/user-attachments/assets/1327e747-5d25-4fca-8188-0a8df6a7b35a)  |  ![Screenshot from 2025-03-07 09-15-07](https://github.com/user-attachments/assets/e91c014f-0a9b-4abc-b9df-25eff9590fb8)|

## Remarks

None.

## Effects on system behavior

None.

## Interface changes

None.
