### PR TITLE
feat(localhost_shutdown): wait for SHUTDOWN_READY state before shuttng down

### DIFF
--- a/boot_shutdown_common/include/boot_shutdown_common/parameter.hpp
+++ b/boot_shutdown_common/include/boot_shutdown_common/parameter.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BOOT_SHUTDOWN__SERVICE__PARAMETER_HPP_
-#define BOOT_SHUTDOWN__SERVICE__PARAMETER_HPP_
+#ifndef BOOT_SHUTDOWN__COMMON__PARAMETER_HPP_
+#define BOOT_SHUTDOWN__COMMON__PARAMETER_HPP_
 
 #include <yaml-cpp/yaml.h>
 
@@ -21,7 +21,7 @@
 #include <string>
 #include <unordered_map>
 
-namespace boot_shutdown_service
+namespace boot_shutdown_common
 {
 
 class Parameter
@@ -57,6 +57,6 @@ private:
   std::unordered_map<std::string, YAML::Node> parameters_;
 };
 
-}  // namespace boot_shutdown_service
+}  // namespace boot_shutdown_common
 
-#endif  // BOOT_SHUTDOWN__SERVICE__PARAMETER_HPP_
+#endif  // BOOT_SHUTDOWN__COMMON__PARAMETER_HPP_

--- a/boot_shutdown_common/include/boot_shutdown_common/parameter.hpp
+++ b/boot_shutdown_common/include/boot_shutdown_common/parameter.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 The Autoware Contributors
+// Copyright 2022-2025 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/boot_shutdown_communication/include/boot_shutdown_communication/service_client.hpp
+++ b/boot_shutdown_communication/include/boot_shutdown_communication/service_client.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 TIER IV, Inc.
+// Copyright 2024-2025 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/boot_shutdown_communication/include/boot_shutdown_communication/service_server.hpp
+++ b/boot_shutdown_communication/include/boot_shutdown_communication/service_server.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 TIER IV, Inc.
+// Copyright 2024-2025 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/boot_shutdown_communication/include/boot_shutdown_communication/topic_publisher.hpp
+++ b/boot_shutdown_communication/include/boot_shutdown_communication/topic_publisher.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 TIER IV, Inc.
+// Copyright 2024-2025 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/boot_shutdown_communication/include/boot_shutdown_communication/topic_subscriber.hpp
+++ b/boot_shutdown_communication/include/boot_shutdown_communication/topic_subscriber.hpp
@@ -1,4 +1,4 @@
-// Copyright 2024 TIER IV, Inc.
+// Copyright 2024-2025 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/boot_shutdown_manager/include/boot_shutdown_manager/boot_shutdown_manager_core.hpp
+++ b/boot_shutdown_manager/include/boot_shutdown_manager/boot_shutdown_manager_core.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 TIER IV, Inc.
+// Copyright 2022-2025 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
+++ b/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 TIER IV, Inc.
+// Copyright 2022-2025 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/boot_shutdown_manager/src/boot_shutdown_manager_node.cpp
+++ b/boot_shutdown_manager/src/boot_shutdown_manager_node.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 TIER IV, Inc.
+// Copyright 2022-2025 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/boot_shutdown_service/CMakeLists.txt
+++ b/boot_shutdown_service/CMakeLists.txt
@@ -20,9 +20,11 @@ target_link_libraries(${PROJECT_NAME}
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<BUILD_INTERFACE:${CMAKE_INSTALL_PREFIX}/../boot_shutdown_internal_msgs/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../boot_shutdown_common/include>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../boot_shutdown_communication/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
   "$<INSTALL_INTERFACE:include/boot_shutdown_internal_msgs>"
+  "$<INSTALL_INTERFACE:include/boot_shutdown_common>"
   "$<INSTALL_INTERFACE:include/boot_shutdown_communication>"
 )
 

--- a/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_service.hpp
+++ b/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_service.hpp
@@ -92,11 +92,15 @@ private:
   ServiceServer<ExecuteShutdownService>::SharedPtr srv_execute_shutdown_;
 
   std::vector<TopicPublisher<EcuStateMessage>::SharedPtr> pub_ecu_state_;
-  EcuStateMessage ecu_state_;
+  
   boost::asio::steady_timer timer_;
-  std::mutex ecu_state_mutex_;
 
-  mutable std::mutex mutex_;
+  // --- Guarded by ecu_state_mutex_ ---
+  std::mutex ecu_state_mutex_;
+  EcuStateMessage ecu_state_;
+
+  // --- Guarded by is_ready_mutex_ ---
+  mutable std::mutex is_ready_mutex_;
   bool is_ready_;
 
   std::chrono::system_clock::time_point startup_time_;

--- a/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_service.hpp
+++ b/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_service.hpp
@@ -42,11 +42,15 @@ class BootShutdownService
 {
 public:
   explicit BootShutdownService(const std::string & config_yaml_path);
+  BootShutdownService(const BootShutdownService&) = delete;
+  BootShutdownService(BootShutdownService&&) = delete;
+  BootShutdownService& operator=(const BootShutdownService&) = delete;
+  BootShutdownService& operator=(BootShutdownService&&) = delete;
   bool initialize();
   void run();
   void shutdown();
 
-protected:
+private:
   static void signalHandler(int signum);
 
   void onPrepareShutdown(const PrepareShutdownService & request, PrepareShutdownService & response);
@@ -59,10 +63,10 @@ protected:
   void prepareShutdown();
   void executeShutdown();
 
-  bool isRunning();
-  bool isStartupTimeout();
-  bool isPreparationTimeout();
-  bool isReady();
+  bool isRunning() const;
+  bool isStartupTimeout() const;
+  bool isPreparationTimeout() const;
+  bool isReady() const;
 
   void setTimestamp(
     google::protobuf::Timestamp * timestamp,
@@ -92,7 +96,7 @@ protected:
   boost::asio::steady_timer timer_;
   std::mutex ecu_state_mutex_;
 
-  std::mutex mutex_;
+  mutable std::mutex mutex_;
   bool is_ready_;
 
   std::chrono::system_clock::time_point startup_time_;

--- a/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_service.hpp
+++ b/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_service.hpp
@@ -80,10 +80,10 @@ private:
   const unsigned short prepare_shutdown_port_;
   const unsigned short execute_shutdown_port_;
 
-  const std::vector<std::string> prepare_shutdown_command_;
   const unsigned int startup_timeout_;
   const unsigned int prepare_shutdown_time_;
   const unsigned int execute_shutdown_time_;
+  const std::vector<std::string> prepare_shutdown_command_;
 
   boost::asio::io_context io_context_;
 

--- a/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_service.hpp
+++ b/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_service.hpp
@@ -17,7 +17,7 @@
 
 #include "boot_shutdown_communication/service_server.hpp"
 #include "boot_shutdown_communication/topic_publisher.hpp"
-#include "boot_shutdown_service/parameter.hpp"
+#include "boot_shutdown_common/parameter.hpp"
 
 #include "boot_shutdown_internal_msgs/ecu_state_message.pb.h"
 #include "boot_shutdown_internal_msgs/execute_shutdown_service.pb.h"
@@ -30,6 +30,7 @@
 namespace boot_shutdown_service
 {
 
+using boot_shutdown_common::Parameter;
 using boot_shutdown_communication::ServiceServer;
 using boot_shutdown_communication::TopicPublisher;
 using boot_shutdown_internal_msgs::msg::EcuStateMessage;
@@ -70,7 +71,7 @@ protected:
   std::string config_yaml_path_;
   Parameter parameter_{config_yaml_path_};
 
-  std::string topic_address_;
+  std::vector<std::string> topic_address_;
   unsigned short topic_port_;
 
   unsigned short prepare_shutdown_port_;
@@ -86,7 +87,7 @@ protected:
   ServiceServer<PrepareShutdownService>::SharedPtr srv_prepare_shutdown_;
   ServiceServer<ExecuteShutdownService>::SharedPtr srv_execute_shutdown_;
 
-  TopicPublisher<EcuStateMessage>::SharedPtr pub_ecu_state_;
+  std::vector<TopicPublisher<EcuStateMessage>::SharedPtr> pub_ecu_state_;
   EcuStateMessage ecu_state_;
   boost::asio::steady_timer timer_;
   std::mutex ecu_state_mutex_;

--- a/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_service.hpp
+++ b/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_service.hpp
@@ -71,19 +71,19 @@ private:
     google::protobuf::Timestamp * timestamp,
     const std::chrono::system_clock::time_point & time_point);
 
-  std::string config_yaml_path_;
+  const std::string config_yaml_path_;
   Parameter parameter_{config_yaml_path_};
 
-  std::vector<std::string> topic_address_;
-  unsigned short topic_port_;
+  const std::vector<std::string> topic_address_;
+  const unsigned short topic_port_;
 
-  unsigned short prepare_shutdown_port_;
-  unsigned short execute_shutdown_port_;
+  const unsigned short prepare_shutdown_port_;
+  const unsigned short execute_shutdown_port_;
 
-  std::vector<std::string> prepare_shutdown_command_;
-  unsigned int startup_timeout_;
-  unsigned int prepare_shutdown_time_;
-  unsigned int execute_shutdown_time_;
+  const std::vector<std::string> prepare_shutdown_command_;
+  const unsigned int startup_timeout_;
+  const unsigned int prepare_shutdown_time_;
+  const unsigned int execute_shutdown_time_;
 
   boost::asio::io_context io_context_;
 

--- a/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_service.hpp
+++ b/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_service.hpp
@@ -15,9 +15,9 @@
 #ifndef BOOT_SHUTDOWN__SERVICE__BOOT_SHUTDOWN_SERVICE_HPP_
 #define BOOT_SHUTDOWN__SERVICE__BOOT_SHUTDOWN_SERVICE_HPP_
 
+#include "boot_shutdown_common/parameter.hpp"
 #include "boot_shutdown_communication/service_server.hpp"
 #include "boot_shutdown_communication/topic_publisher.hpp"
-#include "boot_shutdown_common/parameter.hpp"
 
 #include "boot_shutdown_internal_msgs/ecu_state_message.pb.h"
 #include "boot_shutdown_internal_msgs/execute_shutdown_service.pb.h"
@@ -42,10 +42,11 @@ class BootShutdownService
 {
 public:
   explicit BootShutdownService(const std::string & config_yaml_path);
-  BootShutdownService(const BootShutdownService&) = delete;
-  BootShutdownService(BootShutdownService&&) = delete;
-  BootShutdownService& operator=(const BootShutdownService&) = delete;
-  BootShutdownService& operator=(BootShutdownService&&) = delete;
+  BootShutdownService() = delete;
+  BootShutdownService(const BootShutdownService &) = delete;
+  BootShutdownService(BootShutdownService &&) = delete;
+  BootShutdownService & operator=(const BootShutdownService &) = delete;
+  BootShutdownService & operator=(BootShutdownService &&) = delete;
   bool initialize();
   void run();
   void shutdown();
@@ -90,7 +91,7 @@ private:
   ServiceServer<ExecuteShutdownService>::SharedPtr srv_execute_shutdown_;
 
   std::vector<TopicPublisher<EcuStateMessage>::SharedPtr> pub_ecu_state_;
-  
+
   boost::asio::steady_timer timer_;
 
   // --- Guarded by ecu_state_mutex_ ---

--- a/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_service.hpp
+++ b/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_service.hpp
@@ -51,8 +51,6 @@ public:
   void shutdown();
 
 private:
-  static void signalHandler(int signum);
-
   void onPrepareShutdown(const PrepareShutdownService & request, PrepareShutdownService & response);
   void onExecuteShutdown(const ExecuteShutdownService & request, ExecuteShutdownService & response);
 
@@ -106,7 +104,7 @@ private:
   std::chrono::system_clock::time_point startup_time_;
   std::chrono::system_clock::time_point prepare_shutdown_start_time_;
 
-  static BootShutdownService * instance;
+  boost::asio::signal_set signals_;
 };
 
 }  // namespace boot_shutdown_service

--- a/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_service.hpp
+++ b/boot_shutdown_service/include/boot_shutdown_service/boot_shutdown_service.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 The Autoware Contributors
+// Copyright 2022-2025 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/boot_shutdown_service/src/boot_shutdown_main.cpp
+++ b/boot_shutdown_service/src/boot_shutdown_main.cpp
@@ -21,7 +21,7 @@
 
 void usage()
 {
-  printf("Usage: msr_reader [options]\n");
+  printf("Usage: boot_shutdown_service [options]\n");
   printf("  -h --help   : Display help\n");
   printf("  -c --config : Configuration yaml file path\n");
   printf("\n");

--- a/boot_shutdown_service/src/boot_shutdown_main.cpp
+++ b/boot_shutdown_service/src/boot_shutdown_main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 TIER IV, Inc.
+// Copyright 2022-2025 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/boot_shutdown_service/src/boot_shutdown_main.cpp
+++ b/boot_shutdown_service/src/boot_shutdown_main.cpp
@@ -59,6 +59,7 @@ int main(int argc, char ** argv)
 
   service.run();
 
+  // Safe to call shutdown() multiple times; this ensures explicit finalization.
   service.shutdown();
 
   return EXIT_SUCCESS;

--- a/boot_shutdown_service/src/boot_shutdown_service.cpp
+++ b/boot_shutdown_service/src/boot_shutdown_service.cpp
@@ -217,24 +217,24 @@ void BootShutdownService::executeShutdown()
   thread.detach();
 }
 
-bool BootShutdownService::isRunning()
+bool BootShutdownService::isRunning() const
 {
   return true;
 }
 
-bool BootShutdownService::isStartupTimeout()
+bool BootShutdownService::isStartupTimeout() const
 {
   return (std::chrono::system_clock::now() - startup_time_) >
          std::chrono::seconds(startup_timeout_);
 }
 
-bool BootShutdownService::isPreparationTimeout()
+bool BootShutdownService::isPreparationTimeout() const
 {
   return (std::chrono::system_clock::now() - prepare_shutdown_start_time_) >
          std::chrono::seconds(prepare_shutdown_time_);
 }
 
-bool BootShutdownService::isReady()
+bool BootShutdownService::isReady() const
 {
   bool is_ready = false;
   {

--- a/boot_shutdown_service/src/boot_shutdown_service.cpp
+++ b/boot_shutdown_service/src/boot_shutdown_service.cpp
@@ -183,7 +183,7 @@ void BootShutdownService::publish_ecu_state_message()
 void BootShutdownService::prepareShutdown()
 {
   {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(is_ready_mutex_);
     is_ready_ = false;
   }
 
@@ -200,7 +200,7 @@ void BootShutdownService::prepareShutdown()
       c.wait();
     }
 
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(is_ready_mutex_);
     is_ready_ = true;
   });
 
@@ -238,7 +238,7 @@ bool BootShutdownService::isReady() const
 {
   bool is_ready = false;
   {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(is_ready_mutex_);
     is_ready = is_ready_;
   }
 

--- a/boot_shutdown_service/src/boot_shutdown_service.cpp
+++ b/boot_shutdown_service/src/boot_shutdown_service.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 TIER IV, Inc.
+// Copyright 2022-2025 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/localhost_shutdown/CMakeLists.txt
+++ b/localhost_shutdown/CMakeLists.txt
@@ -3,6 +3,7 @@ project(localhost_shutdown)
 
 find_package(boot_shutdown_internal_msgs REQUIRED)
 find_package(Threads REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 add_executable(${PROJECT_NAME}
   src/localhost_shutdown.cpp
@@ -13,8 +14,10 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<BUILD_INTERFACE:${CMAKE_INSTALL_PREFIX}/../boot_shutdown_internal_msgs/include>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../boot_shutdown_communication/include>"
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../boot_shutdown_common/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
   "$<INSTALL_INTERFACE:include/boot_shutdown_internal_msgs>"
+  "$<INSTALL_INTERFACE:include/boot_shutdown_common>"
   "$<INSTALL_INTERFACE:include/boot_shutdown_communication>"
 )
 
@@ -25,6 +28,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 target_link_libraries(${PROJECT_NAME}
   Threads::Threads
   pthread
+  yaml-cpp
   boot_shutdown_internal_msgs
 )
 

--- a/localhost_shutdown/include/localhost_shutdown/localhost_shutdown.hpp
+++ b/localhost_shutdown/include/localhost_shutdown/localhost_shutdown.hpp
@@ -15,9 +15,9 @@
 #ifndef LOCALHOST_SHUTDOWN__LOCALHOST_SHUTDOWN_HPP_
 #define LOCALHOST_SHUTDOWN__LOCALHOST_SHUTDOWN_HPP_
 
+#include "boot_shutdown_common/parameter.hpp"
 #include "boot_shutdown_communication/service_client.hpp"
 #include "boot_shutdown_communication/topic_subscriber.hpp"
-#include "boot_shutdown_common/parameter.hpp"
 
 #include "boot_shutdown_internal_msgs/ecu_state_message.pb.h"
 #include "boot_shutdown_internal_msgs/execute_shutdown_service.pb.h"
@@ -42,10 +42,11 @@ class LocalhostShutdown
 {
 public:
   explicit LocalhostShutdown(const std::string & config_yaml_path);
-  LocalhostShutdown(const LocalhostShutdown&) = delete;
-  LocalhostShutdown(LocalhostShutdown&&) = delete;
-  LocalhostShutdown& operator=(const LocalhostShutdown&) = delete;
-  LocalhostShutdown& operator=(LocalhostShutdown&&) = delete;
+  LocalhostShutdown() = delete;
+  LocalhostShutdown(const LocalhostShutdown &) = delete;
+  LocalhostShutdown(LocalhostShutdown &&) = delete;
+  LocalhostShutdown & operator=(const LocalhostShutdown &) = delete;
+  LocalhostShutdown & operator=(LocalhostShutdown &&) = delete;
   void initialize();
   void run();
 

--- a/localhost_shutdown/include/localhost_shutdown/localhost_shutdown.hpp
+++ b/localhost_shutdown/include/localhost_shutdown/localhost_shutdown.hpp
@@ -71,7 +71,7 @@ protected:
   EcuStateMessage ecu_state_;
   TopicSubscriber<EcuStateMessage>::SharedPtr sub_ecu_state_;
 
-  std::chrono::steady_clock::time_point prepare_shutdown_timeout_time_;
+  std::chrono::system_clock::time_point prepare_shutdown_timeout_time_;
   boost::asio::steady_timer timer_;
   std::mutex ecu_state_mutex_;
 };

--- a/localhost_shutdown/include/localhost_shutdown/localhost_shutdown.hpp
+++ b/localhost_shutdown/include/localhost_shutdown/localhost_shutdown.hpp
@@ -57,16 +57,16 @@ private:
   void startTimer();
   void onTimer(const boost::system::error_code & error_code);
 
-  std::string config_yaml_path_;
+  const std::string config_yaml_path_;
   Parameter parameter_{config_yaml_path_};
 
-  unsigned short topic_port_;
+  const unsigned short topic_port_;
 
-  std::string service_address_;
-  int service_timeout_;
-  int preparation_timeout_;
-  unsigned short prepare_shutdown_port_;
-  unsigned short execute_shutdown_port_;
+  const std::string service_address_;
+  const int service_timeout_;
+  const int preparation_timeout_;
+  const unsigned short prepare_shutdown_port_;
+  const unsigned short execute_shutdown_port_;
 
   boost::asio::io_context io_context_;
 

--- a/localhost_shutdown/include/localhost_shutdown/localhost_shutdown.hpp
+++ b/localhost_shutdown/include/localhost_shutdown/localhost_shutdown.hpp
@@ -12,27 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef BOOT_SHUTDOWN__SERVICE__LOCALHOST_SHUTDOWN_HPP_
-#define BOOT_SHUTDOWN__SERVICE__LOCALHOST_SHUTDOWN_HPP_
+#ifndef LOCALHOST_SHUTDOWN__LOCALHOST_SHUTDOWN_HPP_
+#define LOCALHOST_SHUTDOWN__LOCALHOST_SHUTDOWN_HPP_
 
 #include "boot_shutdown_communication/service_client.hpp"
+#include "boot_shutdown_communication/topic_subscriber.hpp"
+#include "boot_shutdown_common/parameter.hpp"
 
+#include "boot_shutdown_internal_msgs/ecu_state_message.pb.h"
 #include "boot_shutdown_internal_msgs/execute_shutdown_service.pb.h"
 #include "boot_shutdown_internal_msgs/prepare_shutdown_service.pb.h"
 
 #include <boost/asio.hpp>
 
-namespace boot_shutdown_service
+#include <mutex>
+
+namespace localhost_shutdown
 {
 
+using boot_shutdown_common::Parameter;
 using boot_shutdown_communication::ServiceClient;
+using boot_shutdown_communication::TopicSubscriber;
+using boot_shutdown_internal_msgs::msg::EcuStateMessage;
+using boot_shutdown_internal_msgs::msg::EcuStateType;
 using boot_shutdown_internal_msgs::srv::ExecuteShutdownService;
 using boot_shutdown_internal_msgs::srv::PrepareShutdownService;
 
 class LocalhostShutdown
 {
 public:
-  LocalhostShutdown();
+  explicit LocalhostShutdown(const std::string & config_yaml_path);
   void initialize();
   void run();
 
@@ -40,17 +49,33 @@ protected:
   void prepareShutdown();
   void executeShutdown();
 
+  void startTimer();
+  void onTimer(const boost::system::error_code & error_code);
+
+  std::string config_yaml_path_;
+  Parameter parameter_{config_yaml_path_};
+
+  unsigned short topic_port_;
+
   std::string service_address_;
   int service_timeout_;
+  int preparation_timeout_;
   unsigned short prepare_shutdown_port_;
   unsigned short execute_shutdown_port_;
+
+  boost::asio::io_context io_context_;
 
   ServiceClient<ExecuteShutdownService>::SharedPtr cli_execute_;
   ServiceClient<PrepareShutdownService>::SharedPtr cli_prepare_;
 
-  boost::asio::io_context io_context_;
+  EcuStateMessage ecu_state_;
+  TopicSubscriber<EcuStateMessage>::SharedPtr sub_ecu_state_;
+
+  std::chrono::steady_clock::time_point prepare_shutdown_timeout_time_;
+  boost::asio::steady_timer timer_;
+  std::mutex ecu_state_mutex_;
 };
 
-}  // namespace boot_shutdown_service
+}  // namespace localhost_shutdown
 
-#endif  // BOOT_SHUTDOWN__SERVICE__LOCALHOST_SHUTDOWN_HPP_
+#endif  // LOCALHOST_SHUTDOWN__LOCALHOST_SHUTDOWN_HPP_

--- a/localhost_shutdown/include/localhost_shutdown/localhost_shutdown.hpp
+++ b/localhost_shutdown/include/localhost_shutdown/localhost_shutdown.hpp
@@ -1,4 +1,4 @@
-// Copyright 2022 The Autoware Contributors
+// Copyright 2022-2025 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/localhost_shutdown/include/localhost_shutdown/localhost_shutdown.hpp
+++ b/localhost_shutdown/include/localhost_shutdown/localhost_shutdown.hpp
@@ -42,10 +42,14 @@ class LocalhostShutdown
 {
 public:
   explicit LocalhostShutdown(const std::string & config_yaml_path);
+  LocalhostShutdown(const LocalhostShutdown&) = delete;
+  LocalhostShutdown(LocalhostShutdown&&) = delete;
+  LocalhostShutdown& operator=(const LocalhostShutdown&) = delete;
+  LocalhostShutdown& operator=(LocalhostShutdown&&) = delete;
   void initialize();
   void run();
 
-protected:
+private:
   void prepareShutdown();
   void executeShutdown();
 

--- a/localhost_shutdown/src/localhost_shutdown.cpp
+++ b/localhost_shutdown/src/localhost_shutdown.cpp
@@ -116,13 +116,13 @@ void LocalhostShutdown::onTimer(const boost::system::error_code & error_code)
       ecu_state = ecu_state_;
     }
     if (ecu_state.state() == EcuStateType::SHUTDOWN_READY) {
-      // std::cout << "Shutdown is ready, shutdown." << std::endl;
-      // executeShutdown();
-      // return;
+      std::cout << "Shutdown is ready, shutdown." << std::endl;
+      executeShutdown();
+      return;
     }
     if (std::chrono::system_clock::now() >= prepare_shutdown_timeout_time_) {
       std::cerr << "Shutdown timeout reached, forcing shutdown." << std::endl;
-      // executeShutdown();
+      executeShutdown();
       return;
     }
     startTimer();

--- a/localhost_shutdown/src/localhost_shutdown.cpp
+++ b/localhost_shutdown/src/localhost_shutdown.cpp
@@ -121,7 +121,7 @@ void LocalhostShutdown::onTimer(const boost::system::error_code & error_code)
       executeShutdown();
       return;
     }
-    if (std::chrono::system_clock::now() >= prepare_shutdown_timeout_time_) {
+    else if (std::chrono::system_clock::now() >= prepare_shutdown_timeout_time_) {
       std::cerr << "Shutdown timeout reached, forcing shutdown." << std::endl;
       executeShutdown();
       return;

--- a/localhost_shutdown/src/localhost_shutdown.cpp
+++ b/localhost_shutdown/src/localhost_shutdown.cpp
@@ -14,6 +14,7 @@
 
 #include "localhost_shutdown/localhost_shutdown.hpp"
 
+#include <iomanip>
 #include <iostream>
 
 #define FMT_HEADER_ONLY

--- a/localhost_shutdown/src/localhost_shutdown.cpp
+++ b/localhost_shutdown/src/localhost_shutdown.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 TIER IV, Inc.
+// Copyright 2022-2025 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/localhost_shutdown/src/localhost_shutdown_main.cpp
+++ b/localhost_shutdown/src/localhost_shutdown_main.cpp
@@ -15,10 +15,45 @@
 #include "localhost_shutdown/localhost_shutdown.hpp"
 
 #include <errno.h>
+#include <getopt.h>
+#include <string.h>
+#include <unistd.h>
+
+void usage()
+{
+  printf("Usage: localhost_shutdown [options]\n");
+  printf("  -h --help   : Display help\n");
+  printf("  -c --config : Configuration yaml file path\n");
+  printf("\n");
+}
 
 int main(int argc, char ** argv)
 {
-  boot_shutdown_service::LocalhostShutdown shutdown;
+  static struct option long_options[] = {
+    {"help", no_argument, 0, 'h'}, {"config", required_argument, nullptr, 'c'}, {0, 0, 0, 0}};
+
+  int c = 0;
+  int option_index = 0;
+
+  const std::string default_config_yaml_path = "/etc/localhost_shutdown/localhost_shutdown.param.yaml";
+  std::string config_yaml_path = default_config_yaml_path;
+
+  while ((c = getopt_long(argc, argv, "hc:", long_options, &option_index)) != -1) {
+    switch (c) {
+      case 'h':
+        usage();
+        return EXIT_SUCCESS;
+
+      case 'c':
+        config_yaml_path = optarg;
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  localhost_shutdown::LocalhostShutdown shutdown(config_yaml_path);
 
   shutdown.initialize();
   shutdown.run();

--- a/localhost_shutdown/src/localhost_shutdown_main.cpp
+++ b/localhost_shutdown/src/localhost_shutdown_main.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022 TIER IV, Inc.
+// Copyright 2022-2025 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

1. Modify `localhost_shutdown` to wait for `SHUTDOWN_READY` from `boot_shutdown_service` before issuing a shutdown request
    Add a process in `localhost_shutdown` to receive the status from `boot_shutdown_service` (e.g., `SHUTDOWN_READY`).

2. Expand notification destinations
    Previously, `boot_shutdown_service` only notified `boot_shutdown_manager`.
    Modify it so that `localhost_shutdown` can also receive the status.
    Update the `topic_address` configuration to support multiple notification targets (e.g., as a list or semicolon-separated string).

3. Parameterize `localhost_shutdown` settings
    The configuration of `localhost_shutdown` was hardcoded.
    Modify it to allow configuration via parameters (e.g., `topic address`, ports) using a config file.
    This allows flexible setup depending on the environment.

## Purpose
- Ensure accurate control of the shutdown timing and enable a safe shutdown process.
- Improve extensibility by allowing multiple recipients for status notifications.
- Eliminate hardcoded settings to enhance reusability and maintainability.

## Links
[TIER IV INTERNAL JIRA LINK](https://tier4.atlassian.net/browse/RT0-37254)

## Tests performed

- Verified that `localhost_shutdown` waits for `SHUTDOWN_READY` before sending the shutdown request.
- Confirmed that both `localhost_shutdown` and `boot_shutdown_manager` receive status messages from `boot_shutdown_service`.
- Tested parameterized configuration by changing topic address and port via config file.
- Ensured shutdown sequence behaves correctly under normal and delayed `SHUTDOWN_READY` scenarios.

## Remarks

None.

## Effects on system behavior

None.

## Interface changes

None.
