### PR TITLE
feat(boot-boot_shutdown_manager): run shutdown requests in parallel

### DIFF
--- a/boot_shutdown_manager/config/boot_shutdown_manager.param.yaml
+++ b/boot_shutdown_manager/config/boot_shutdown_manager.param.yaml
@@ -15,9 +15,9 @@
 #         logic: [AND, OR] condition for fields within topic
 #         {field_name}: A condition [eq, ne, le, lt, ge, gt, contains, not_contains]: {value} applied to the message field
 #
-#   aggregation_timeout_sec: 60  Maximum time (in seconds) to wait for all ECUs to respond
-#                                during prepare or execute shutdown aggregation.
-#                                If exceeded, remaining ECUs are logged as timeout.
+#   aggregation_timeout_sec: 60.0 Maximum time (in seconds) to wait for all ECUs to respond
+#                                 during prepare or execute shutdown aggregation.
+#                                 If exceeded, remaining ECUs are logged as timeout.
 #
 # Note:
 # default values are:
@@ -41,7 +41,7 @@
     preparation_timeout: 10.0
     topic_port: 10000
     service_timeout: 1
-    aggregation_timeout_sec: 60
+    aggregation_timeout_sec: 60.0
     managed_ecu:
       autoware_ecu:
         state: /autoware_ecu/get/ecu_state

--- a/boot_shutdown_manager/config/boot_shutdown_manager.param.yaml
+++ b/boot_shutdown_manager/config/boot_shutdown_manager.param.yaml
@@ -15,6 +15,10 @@
 #         logic: [AND, OR] condition for fields within topic
 #         {field_name}: A condition [eq, ne, le, lt, ge, gt, contains, not_contains]: {value} applied to the message field
 #
+#   aggregation_timeout_sec: 60  Maximum time (in seconds) to wait for all ECUs to respond
+#                                during prepare or execute shutdown aggregation.
+#                                If exceeded, remaining ECUs are logged as timeout.
+#
 # Note:
 # default values are:
 #   state: /{ecu_name}/get/ecu_state
@@ -37,6 +41,7 @@
     preparation_timeout: 10.0
     topic_port: 10000
     service_timeout: 1
+    aggregation_timeout_sec: 60
     managed_ecu:
       autoware_ecu:
         state: /autoware_ecu/get/ecu_state

--- a/boot_shutdown_manager/include/boot_shutdown_manager/boot_shutdown_manager_core.hpp
+++ b/boot_shutdown_manager/include/boot_shutdown_manager/boot_shutdown_manager_core.hpp
@@ -92,6 +92,7 @@ private:
   std::thread io_thread_;
   unsigned short topic_port_;
   int service_timeout_;
+  double aggregation_timeout_sec_;
   std::atomic<bool> shutdown_ready_{true};
 
   topic_condition_evaluator::TopicConditionEvaluator topic_condition_evaluator_;

--- a/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
+++ b/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
@@ -459,6 +459,8 @@ void BootShutdownManager::executeShutdown()
         }
         if (result.ok && result.power_off > latest_power_off_time) {
           latest_power_off_time = result.power_off;
+          // Update the power-off time in the published ECU state summary
+          ecu_state_summary_.summary.power_off_time = latest_power_off_time;
         }
         --remaining;
         progressed = true;
@@ -488,7 +490,6 @@ void BootShutdownManager::executeShutdown()
   }
 
   is_shutting_down = true;
-  ecu_state_summary_.summary.power_off_time = latest_power_off_time;
 }
 
 rclcpp::Time BootShutdownManager::convertToRclcppTime(

--- a/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
+++ b/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
@@ -14,6 +14,8 @@
 
 #include "boot_shutdown_manager/boot_shutdown_manager_core.hpp"
 
+#include <future>
+
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
 
@@ -65,6 +67,7 @@ BootShutdownManager::BootShutdownManager()
   get_parameter_or("preparation_timeout", preparation_timeout_, 60.0);
   get_parameter_or("topic_port", topic_port_, static_cast<unsigned short>(10000));
   get_parameter_or("service_timeout", service_timeout_, 1);
+  get_parameter_or("aggregation_timeout_sec", aggregation_timeout_sec_, 60.0);
 
   ecu_state_summary_.summary.state = EcuState::STARTUP;
   last_transition_stamp_ = now();
@@ -188,22 +191,84 @@ void BootShutdownManager::onShutdownService(
     return;
   }
 
+  // Local struct to hold the result of each ECU's asynchronous prepare call.
+  struct Result
+  {
+    std::string ecu;
+    bool ok;
+    std::string msg;
+  };
+
+  // Map: ECU name → async future
+  std::map<std::string, std::future<Result>> futures;
+
   for (auto & [ecu_name, client] : ecu_client_queue_) {
     if (client->skip_shutdown) {
       continue;
     }
 
-    try {
-      PrepareShutdownService req;
-      auto resp = client->cli_prepare->call(req);
-      if (!resp) {
-        RCLCPP_WARN(get_logger(), "Prepare shutdown service call failed");
-        continue;
+    futures.emplace(ecu_name, std::async(std::launch::async, [this, ecu_name, client]() -> Result {
+      try {
+        PrepareShutdownService req;
+        auto resp = client->cli_prepare->call(req);
+        if (!resp) {
+          return {ecu_name, false, "failed"};
+        }
+        return {ecu_name, true, ""};
+      } catch (const std::runtime_error & e) {
+        return {ecu_name, false, e.what()};
+      } catch (...) {
+        return {ecu_name, false, "unknown error"};
       }
-    } catch (const std::runtime_error & e) {
-      RCLCPP_WARN(get_logger(), "%s", e.what());
-    } catch (...) {
-      RCLCPP_WARN(get_logger(), "Unknown error occurred");
+    }));
+  }
+
+  // Wait for all futures to complete or until the timeout expires.
+  // Poll periodically to detect progress and apply an overall deadline.
+  const auto timeout =
+    std::chrono::milliseconds(static_cast<int>(aggregation_timeout_sec_ * 1000.0));
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+
+  size_t remaining = futures.size();
+
+  // Wait loop
+  while (remaining > 0) {
+    bool progressed = false;
+
+    // Iterate with structured binding to access the future object.
+    for (auto & [ecu_name, future] : futures) {
+      if (!future.valid()) continue;
+
+      // Non-blocking check for completion.
+      if (future.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready) {
+        auto result = future.get();
+        if (!result.ok) {
+          RCLCPP_WARN(get_logger(), "Prepare failed on %s: %s", result.ecu.c_str(), result.msg.c_str());
+        }
+        --remaining;
+        progressed = true;
+      }
+    }
+
+    // If no task finished in this cycle, check for timeout.
+    if (!progressed) {
+      if (std::chrono::steady_clock::now() >= deadline) {
+        // Timeout reached → collect unfinished ECUs
+        std::ostringstream stream;
+        for (auto & [ecu_name, future] : futures) {
+          if (future.valid() &&
+              future.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
+            stream << ecu_name << " ";
+          }
+        }
+        RCLCPP_WARN(get_logger(), "Prepare timeout: remaining %zu ECUs → %s",
+                    remaining, stream.str().c_str());
+        // Exit on timeout.
+        break;
+      }
+
+      // Small sleep to prevent busy looping (CPU friendly).
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
   }
 
@@ -218,8 +283,9 @@ void BootShutdownManager::onShutdownService(
 
   ecu_state_summary_.summary.state = EcuState::SHUTDOWN_PREPARING;
   last_transition_stamp_ = now();
-  RCLCPP_INFO(get_logger(), "State transioned : -> SHUTDOWN_PREPARING");
+  RCLCPP_INFO(get_logger(), "State transitioned : -> SHUTDOWN_PREPARING");
 
+  // Keep the interface/behavior: always report success here.
   response->status.success = true;
 }
 
@@ -336,26 +402,88 @@ void BootShutdownManager::executeShutdown()
   rclcpp::Clock clock(RCL_SYSTEM_TIME);
   rclcpp::Time latest_power_off_time = clock.now();
 
+  // Local struct to hold the result of each ECU's asynchronous prepare call.
+  struct Result {
+    std::string ecu;
+    bool ok;
+    std::string msg;
+    rclcpp::Time power_off;
+  };
+
+  // Map: ECU name -> async future.
+  std::map<std::string, std::future<Result>> futures;
+
   for (auto & [ecu_name, client] : ecu_client_queue_) {
     if (client->skip_shutdown) {
       continue;
     }
 
-    try {
-      ExecuteShutdownService req;
-      auto resp = client->cli_execute->call(req);
-      if (!resp) {
-        RCLCPP_WARN(get_logger(), "Execute shutdown service call failed");
-        continue;
+    futures.emplace(ecu_name, std::async(std::launch::async, [this, ecu_name, client]() -> Result {
+      try {
+        ExecuteShutdownService req;
+        auto resp = client->cli_execute->call(req);
+        if (!resp) {
+          return Result{ecu_name, false, "failed", rclcpp::Time{}};
+        }
+        rclcpp::Time power_off_time = convertToRclcppTime(resp->power_off_time());
+        return Result{ecu_name, true, "", power_off_time};
+      } catch (const std::runtime_error & e) {
+        return Result{ecu_name, false, e.what(), rclcpp::Time{}};
+      } catch (...) {
+        return Result{ecu_name, false, "unknown error", rclcpp::Time{}};
       }
-      rclcpp::Time power_off_time = convertToRclcppTime(resp->power_off_time());
-      if (latest_power_off_time < power_off_time) {
-        latest_power_off_time = power_off_time;
+    }));
+  }
+
+  // Wait for all futures to complete or until the timeout expires.
+  // Poll periodically to detect progress and apply an overall deadline.
+  const auto timeout =
+    std::chrono::milliseconds(static_cast<int>(aggregation_timeout_sec_ * 1000.0));
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+
+  size_t remaining = futures.size();
+
+  // Wait loop
+  while (remaining > 0) {
+    bool progressed = false;
+
+    // Iterate with structured binding to access the future object.
+    for (auto & [ecu_name, future] : futures) {
+      if (!future.valid()) continue;
+
+      // Non-blocking check for completion.
+      if (future.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready) {
+        auto result = future.get();
+        if (!result.ok) {
+          RCLCPP_WARN(get_logger(), "Execute failed on %s: %s", result.ecu.c_str(), result.msg.c_str());
+        }
+        if (result.ok && result.power_off > latest_power_off_time) {
+          latest_power_off_time = result.power_off;
+        }
+        --remaining;
+        progressed = true;
       }
-    } catch (const std::runtime_error & e) {
-      RCLCPP_WARN(get_logger(), "%s", e.what());
-    } catch (...) {
-      RCLCPP_WARN(get_logger(), "Unknown error occurred");
+    }
+
+    // If no task finished in this cycle, check for timeout.
+    if (!progressed) {
+      if (std::chrono::steady_clock::now() >= deadline) {
+        // Timeout reached → collect unfinished ECUs
+        std::ostringstream stream;
+        for (auto & [ecu_name, future] : futures) {
+          if (future.valid() &&
+              future.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
+            stream << ecu_name << " ";
+          }
+        }
+        RCLCPP_WARN(get_logger(), "Execute timeout: remaining %zu ECUs → %s",
+                    remaining, stream.str().c_str());
+        // Exit on timeout.
+        break;
+      }
+
+      // Small sleep to prevent busy looping (CPU friendly).
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
   }
 

--- a/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
+++ b/boot_shutdown_manager/src/boot_shutdown_manager_core.cpp
@@ -237,8 +237,9 @@ void BootShutdownManager::onShutdownService(
 
     // Iterate with structured binding to access the future object.
     for (auto & [ecu_name, future] : futures) {
-      if (!future.valid()) continue;
-
+      if (!future.valid()) {
+        continue;
+      }
       // Non-blocking check for completion.
       if (future.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready) {
         auto result = future.get();
@@ -449,8 +450,9 @@ void BootShutdownManager::executeShutdown()
 
     // Iterate with structured binding to access the future object.
     for (auto & [ecu_name, future] : futures) {
-      if (!future.valid()) continue;
-
+      if (!future.valid()) {
+        continue;
+      }
       // Non-blocking check for completion.
       if (future.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready) {
         auto result = future.get();


### PR DESCRIPTION
## Description
Implemented parallel shutdown handling for multiple ECUs.
Each ECU’s `prepare_shutdown` and `execute_shutdown` services are now called asynchronously,
with timeout monitoring (`aggregation_timeout_sec`) to detect and log unresponsive ECUs.
Improves system robustness and prevents indefinite blocking during coordinated shutdown.

## Links
[TIER IV INTERNAL JIRA LINK](https://tier4.atlassian.net/browse/VEH-2913)

## Remarks
- Added detailed timeout logging for ECUs that did not complete within the aggregation window.
- Maintains backward compatibility with existing service interfaces.
- No changes to message definitions.

## Interface changes
None.

## Tests performed
1. Verified normal shutdown flow across all ECUs (main, sub, signage, voice-system, logging).
    <img width="1721" height="2033" alt="image" src="https://github.com/user-attachments/assets/40cb1834-d4d1-4a9e-86d1-e90d778f15b7" />

2. Confirmed timeout log is emitted when one or more ECUs do not respond.
    <img width="1723" height="1663" alt="image" src="https://github.com/user-attachments/assets/a573f213-dbd1-4068-b5fb-2f884ffa056a" />

3. Ensured aggregation_timeout_sec parameter correctly limits total wait time.
    `aggregation_timeout_sec: 240.0`

    ```console
    Oct 22 14:53:14 [boot_shutdown_manager-1] Service request sent: /api/main/execute_shutdown,192.168.20.11:10002
    Oct 22 14:55:22 [boot_shutdown_manager-1] Service response received
    ```
    Verified that the timeout mechanism works as expected.
    <img width="1706" height="2009" alt="image" src="https://github.com/user-attachments/assets/a22d321a-1ccf-481a-9160-e430f018ba4a" />
